### PR TITLE
Ignore java files for Sonar analysis #17

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,3 @@
 sonar.projectKey=vscode-didact
 sonar.projectName=VS Code Didact
+sonar.exclusions=**/*.java


### PR DESCRIPTION
Sonar analysis requires compiled Java classes to do analysis. The Java
files provided are snippets that are nto compiled so exlucing them.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>