### PR TITLE
Issue #101 - Persist current column for webview

### DIFF
--- a/src/didactWebView.ts
+++ b/src/didactWebView.ts
@@ -92,13 +92,13 @@ export class DidactWebviewPanel {
 		}
 	}
 
-	public static async createOrShow(extensionPath: string, inpath?: vscode.Uri | undefined, column?: ViewColumn) {
+	public static createOrShow(extensionPath: string, inpath?: vscode.Uri | undefined, column?: ViewColumn) {
 		if (!column) {
 			// if we weren't passed a column, use the last column setting
-			column = await getLastColumnUsedSetting();
+			column = getLastColumnUsedSetting();
 		} else {
 			// if we are passed a column, stash it
-			await setLastColumnUsedSetting(column);
+			setLastColumnUsedSetting(column);
 		}
 
 		// If we already have a panel, dispose it to reset the resource roots

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ import { extensionFunctions, initializeContext } from './extensionFunctions';
 import * as commandConstants from './extensionFunctions';
 import { DidactWebviewPanel } from './didactWebView';
 import { DidactNodeProvider, TreeNode } from './nodeProvider';
-import { registerTutorial, clearRegisteredTutorials, setContext } from './utils';
+import { registerTutorial, clearRegisteredTutorials } from './utils';
 import * as path from 'path';
 import {DidactUriCompletionItemProviderMarkdown} from './didactUriCompletionItemProviderMarkdown';
 import {DidactUriCompletionItemProviderAsciiDoc} from './didactUriCompletionItemProviderAsciiDoc';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -200,8 +200,8 @@ export function setContext(inContext: vscode.ExtensionContext) {
 	context = inContext;
 }
 
-export async function getLastColumnUsedSetting() : Promise<number> {
-	let lastColumn : number | undefined = await context.workspaceState.get(DIDACT_COLUMN_SETTING);
+export function getLastColumnUsedSetting() : number {
+	let lastColumn : number | undefined = context.workspaceState.get(DIDACT_COLUMN_SETTING);
 	if (!lastColumn) {
 		// if we can, grab the current column from the active text editor
 		if (vscode.window.activeTextEditor) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,11 +18,13 @@
 import * as vscode from 'vscode';
 import * as extension from './extension';
 import * as fs from 'fs';
-import * as path from 'path';
+import { ViewColumn } from 'vscode';
+
 
 export const DIDACT_DEFAULT_URL : string = 'didact.defaultUrl';
 export const DIDACT_REGISTERED_SETTING : string = 'didact.registered';
 export const DIDACT_NOTIFICATION_SETTING : string = 'didact.disableNotifications';
+export const DIDACT_COLUMN_SETTING : string = 'didact.lastColumnUsed';
 
 // stashed extension context
 let context : vscode.ExtensionContext;
@@ -196,4 +198,23 @@ export async function getCurrentFileSelectionPath(): Promise<vscode.Uri> {
 // stash the context so we have it for use by the command functions without passing it each time
 export function setContext(inContext: vscode.ExtensionContext) {
 	context = inContext;
+}
+
+export async function getLastColumnUsedSetting() : Promise<number> {
+	let lastColumn : number | undefined = await context.workspaceState.get(DIDACT_COLUMN_SETTING);
+	if (!lastColumn) {
+		// if we can, grab the current column from the active text editor
+		if (vscode.window.activeTextEditor) {
+			lastColumn = vscode.window.activeTextEditor.viewColumn;
+		}
+		// otherwise assume it's the first column
+		if (!lastColumn) {
+			lastColumn = ViewColumn.One;
+		}
+	}
+	return lastColumn;
+}
+
+export async function setLastColumnUsedSetting(column: number | undefined) {
+	await context.workspaceState.update(DIDACT_COLUMN_SETTING, column);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -202,13 +202,13 @@ export function setContext(inContext: vscode.ExtensionContext) {
 
 export function getLastColumnUsedSetting() : number {
 	let lastColumn : number | undefined = context.workspaceState.get(DIDACT_COLUMN_SETTING);
-	if (!lastColumn) {
+	if (lastColumn === undefined) {
 		// if we can, grab the current column from the active text editor
 		if (vscode.window.activeTextEditor) {
 			lastColumn = vscode.window.activeTextEditor.viewColumn;
 		}
 		// otherwise assume it's the first column
-		if (!lastColumn) {
+		if (lastColumn === undefined) {
 			lastColumn = ViewColumn.One;
 		}
 	}


### PR DESCRIPTION
Expanding on https://github.com/redhat-developer/vscode-didact/pull/127, this change actually persists the view column when it gets moved so the next time a didact view opens it opens in a consistent manner. 

Signed-off-by: bfitzpat@redhat.com <bfitzpat@redhat.com>