### PR TITLE
Allowing number to be passed as a command argument

### DIFF
--- a/src/commandHandler.ts
+++ b/src/commandHandler.ts
@@ -95,7 +95,7 @@ export async function processInputs(incoming : string, extensionPath? : string) 
 			if (query.number) {
 				const text = getValue(query.number);
 				if (text) {
-					output.push(+text);
+					handleNumber(output, text);
 				}
 			}
 
@@ -214,6 +214,11 @@ async function collectUserInput(args: string[]) : Promise<string[]> {
 		}
 	}
 	return outArgs;
+}
+
+
+export function handleNumber(output: any[], text: string) {
+	output.push(+text);
 }
 
 // actually call the command with all the various inputs collected

--- a/src/commandHandler.ts
+++ b/src/commandHandler.ts
@@ -92,6 +92,12 @@ export async function processInputs(incoming : string, extensionPath? : string) 
 					await handleUser(user, output, errorMessage);
 				}
 			}
+			if (query.number) {
+				const text = getValue(query.number);
+				if (text) {
+					output.push(+text);
+				}
+			}
 
 			console.log(`commandId : ${commandId}`);
 			console.log(`output : ${output.toString()}`);

--- a/src/test/suite/commandHandler.test.ts
+++ b/src/test/suite/commandHandler.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import { expect } from 'chai';
+import { handleNumber } from '../../commandHandler';
+
+suite("Command Handler tests", function () {
+
+        test("Ensure that we can pass a number to a command", () => {
+                let output: any[] = [];
+                handleNumber(output, '2');
+                expect(output[0]).to.be.a('number');
+                expect(output[0]).to.equal(2);
+        })
+
+});


### PR DESCRIPTION
For instance, when opening a file 
```
[Open the org.quickperf.jvm.JvmAnnotationsJunit4Test class](didact://?commandId=vscode.open&projectFilePath=jvm-junit4%2Fsrc%2Ftest%2Fjava%2Forg%2Fquickperf%2Fjvm%2FJvmAnnotationsJunit4Test.java&number=2)
```
it would pass the number 2 as the second argument of `vscode.open` (columnOrOptions is expecting a number)

> vscode.open - Opens the provided resource in the editor.
>
> resource - Resource to open
> columnOrOptions - (optional) Either the column in which to open or editor options, see vscode.TextDocumentShowOptions
