### PR TITLE
Issue102 adding history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the "vscode-didact" extension will be documented in this 
  - Adding extension setting to enable opening the default Didact file at startup. [#144](https://github.com/redhat-developer/vscode-didact/issues/144)
  - Switching to xmldom for heading parsing and better Typescript 4 support
  - Adding ability to open a Didact file in a different column by default
+ - Adding simple history to enable stepping forward/back through last few Didact tutorials [#102](https://github.com/redhat-developer/vscode-didact/issues/102)
 
 ## 0.1.16
 

--- a/media/main.js
+++ b/media/main.js
@@ -22,17 +22,6 @@ function () {
 	//connect to the vscode api
 	const vscode = acquireVsCodeApi();
 
-	class Window_History {  
-		Back() {
-			window.history.back();
-		}
-		Forward() {
-			window.history.forward();
-		}
-	}
-
-	var obj = new Window_History();
-
 	document.body.addEventListener('click', event => {
 		let node = event && event.target;
 		while (node) {
@@ -119,14 +108,6 @@ function () {
 						}
 					}
 				}
-				break;
-			case 'back':
-				console.log(`Going back`);
-				obj.Back();
-				break;
-			case 'forward':
-				console.log(`Going forward`);
-				obj.Forward();
 				break;
 		}
 	});

--- a/media/main.js
+++ b/media/main.js
@@ -22,6 +22,17 @@ function () {
 	//connect to the vscode api
 	const vscode = acquireVsCodeApi();
 
+	class Window_History {  
+		Back() {
+			window.history.back();
+		}
+		Forward() {
+			window.history.forward();
+		}
+	}
+
+	var obj = new Window_History();
+
 	document.body.addEventListener('click', event => {
 		let node = event && event.target;
 		while (node) {
@@ -79,36 +90,44 @@ function () {
 				const requirementName = json.requirementName;
 				const isAvailable = json.result;
 
+				let requirementMessage = 'Not currently available';
 				let element = document.getElementById(requirementName);
 				if (element) {
-					let message = 'Not currently avaialable';
 					let green = "green";
 					let red = "red";
 					if (String(isAvailable).toLowerCase() === 'true') {
-						message = 'Available';
+						requirementMessage = 'Available';
 						element.style.color = green;
 					} else {
-						message = 'Unavailable';
+						requirementMessage = 'Unavailable';
 						element.style.color = red;
 					}
-					element.textContent = `Status: ${message}`;
+					element.textContent = `Status: ${requirementMessage}`;
 				}
 				console.log(`${requirementName} is available: ${isAvailable}`);
 				break;
 			case 'allRequirementCheck':
 				var links = collectElements("a");
 				for (let index = 0; index < links.length; index++) {
-					const element = links[index];
-					if (element.getAttribute('href')) {
-						const href = element.getAttribute('href');
+					const linkElements = links[index];
+					if (linkElements.getAttribute('href')) {
+						const href = linkElements.getAttribute('href');
 						for(let check of requirementCommandLinks) {
 							if (href.startsWith(check)) {
-								element.click();
+								linkElements.click();
 							}
 						}
 					}
 				}
 				break;
-			}
+			case 'back':
+				console.log(`Going back`);
+				obj.Back();
+				break;
+			case 'forward':
+				console.log(`Going forward`);
+				obj.Forward();
+				break;
+		}
 	});
 }());

--- a/package.json
+++ b/package.json
@@ -131,13 +131,13 @@
 				"command": "vscode.didact.historyBack",
 				"key": "ctrl+shift+left",
 				"mac": "cmd+shift+left",
-				"when": "view == didact"
+				"when": "didact.webview"
 			},
 			{
 				"command": "vscode.didact.historyForward",
 				"key": "ctrl+shift+right",
 				"mac": "cmd+shift+right",
-				"when": "activeEditor == didact"
+				"when": "didact.webview"
 			}
 		],
 		"menus": {

--- a/package.json
+++ b/package.json
@@ -129,14 +129,14 @@
 			},
 			{
 				"command": "vscode.didact.historyBack",
-				"key": "ctrl+shift+left",
-				"mac": "cmd+shift+left",
+				"key": "alt+down",
+				"mac": "alt+down",
 				"when": "didact.webview"
 			},
 			{
 				"command": "vscode.didact.historyForward",
-				"key": "ctrl+shift+right",
-				"mac": "cmd+shift+right",
+				"key": "alt+up",
+				"mac": "alt+up",
 				"when": "didact.webview"
 			}
 		],

--- a/package.json
+++ b/package.json
@@ -112,12 +112,17 @@
 			{
 				"command": "vscode.didact.historyBack",
 				"title": "Move Backward One Item in the Didact History",
-				"when": "resourceFilename =~ /[.](didact)[.](md|adoc)$/"
+				"when": "didact.webview"
 			},
 			{
 				"command": "vscode.didact.historyForward",
 				"title": "Move Forward One Item in the Didact History",
-				"when": "resourceFilename =~ /[.](didact)[.](md|adoc)$/"
+				"when": "didact.webview"
+			},
+			{
+				"command": "vscode.didact.clearHistory",
+				"title": "Clears the Didact History",
+				"when": "didact.webview"
 			}
 		],
 		"keybindings": [

--- a/package.json
+++ b/package.json
@@ -111,17 +111,17 @@
 			},
 			{
 				"command": "vscode.didact.historyBack",
-				"title": "Move Backward One Item in the Didact History",
+				"title": "Didact: Show Previous Entry in the Didact History",
 				"when": "didact.webview"
 			},
 			{
 				"command": "vscode.didact.historyForward",
-				"title": "Move Forward One Item in the Didact History",
+				"title": "Didact: Show Next Entry in the Didact History",
 				"when": "didact.webview"
 			},
 			{
 				"command": "vscode.didact.clearHistory",
-				"title": "Clears the Didact History",
+				"title": "Didact: Clear History",
 				"when": "didact.webview"
 			}
 		],

--- a/package.json
+++ b/package.json
@@ -108,6 +108,16 @@
 				"command": "vscode.didact.verifyCommands",
 				"title": "Validate Didact File",
 				"when": "resourceFilename =~ /[.](didact)[.](md|adoc)$/"
+			},
+			{
+				"command": "vscode.didact.historyBack",
+				"title": "Move Backward One Item in the Didact History",
+				"when": "resourceFilename =~ /[.](didact)[.](md|adoc)$/"
+			},
+			{
+				"command": "vscode.didact.historyForward",
+				"title": "Move Forward One Item in the Didact History",
+				"when": "resourceFilename =~ /[.](didact)[.](md|adoc)$/"
 			}
 		],
 		"keybindings": [
@@ -116,6 +126,18 @@
 				"key": "ctrl+shift+v",
 				"mac": "cmd+shift+v",
 				"when": "editorFocus && resourceFilename =~ /[.](didact)[.](md|adoc)$/"
+			},
+			{
+				"command": "vscode.didact.historyBack",
+				"key": "ctrl+shift+left",
+				"mac": "cmd+shift+left",
+				"when": "view == didact"
+			},
+			{
+				"command": "vscode.didact.historyForward",
+				"key": "ctrl+shift+right",
+				"mac": "cmd+shift+right",
+				"when": "activeEditor == didact"
 			}
 		],
 		"menus": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
 		"Other"
 	],
 	"activationEvents": [
-		"*"
+		"*",
+		"onWebviewPanel:didact"
 	],
 	"main": "./out/extension.js",
 	"contributes": {

--- a/src/didactWebView.ts
+++ b/src/didactWebView.ts
@@ -445,7 +445,7 @@ export class DidactWebviewPanel {
 				const filePath = path.join(cachePath, filename);
 				try {
 					if (fs.existsSync(filePath)) {
-						let contents = fs.readFileSync(filePath);
+						const contents : Buffer = fs.readFileSync(filePath);
 						return contents.toLocaleString();
 					}
 				} catch (error) {

--- a/src/didactWebView.ts
+++ b/src/didactWebView.ts
@@ -31,6 +31,10 @@ export class DidactWebviewPanel {
 	public static currentPanel: DidactWebviewPanel | undefined;
 
 	public static readonly viewType = 'didact';
+	private static readonly didactCachePath = `didact/cache`;
+	private static readonly didactCacheHtmlFile = 'currentHtml.html';
+	private static readonly didactCacheTitleFile = 'currentTitle.txt';
+	private static readonly didactCacheUriFile = 'currentUri.txt';
 
 	private readonly _panel: vscode.WebviewPanel;
 	private readonly _extensionPath: string;
@@ -411,16 +415,21 @@ export class DidactWebviewPanel {
 			if (!DidactWebviewPanel.context.globalStoragePath) {
 				fs.mkdirSync(DidactWebviewPanel.context.globalStoragePath, { recursive: true });
 			}
-			const cachePath = path.join(DidactWebviewPanel.context.globalStoragePath, `didact/cache`);
-			const htmlFilePath = path.join(cachePath, 'currentHtml.html');
-			const titleFilePath = path.join(cachePath, 'currentTitle.txt');
+			const cachePath = path.join(DidactWebviewPanel.context.globalStoragePath, DidactWebviewPanel.didactCachePath);
+			const htmlFilePath = path.join(cachePath, DidactWebviewPanel.didactCacheHtmlFile);
+			const titleFilePath = path.join(cachePath, DidactWebviewPanel.didactCacheTitleFile);
+			const uriFilePath = path.join(cachePath, DidactWebviewPanel.didactCacheUriFile);
 			try {
 				if (!fs.existsSync(cachePath)) {
-					fs.mkdirSync(path.join(DidactWebviewPanel.context.globalStoragePath, `didact/cache`), { recursive: true });
+					fs.mkdirSync(path.join(DidactWebviewPanel.context.globalStoragePath, DidactWebviewPanel.didactCachePath), { recursive: true });
 				}
 				fs.writeFileSync(htmlFilePath, html, {encoding:'utf8', flag:'w'});
 				if (DidactWebviewPanel.currentPanel) {
 					fs.writeFileSync(titleFilePath, DidactWebviewPanel.currentPanel.defaultTitle, {encoding:'utf8', flag:'w'});
+
+					if (DidactWebviewPanel.currentPanel.didactUriPath) {
+						fs.writeFileSync(uriFilePath, DidactWebviewPanel.currentPanel.didactUriPath.fsPath, {encoding:'utf8', flag:'w'});
+					}
 				}
 			}
 			catch (error) {
@@ -428,36 +437,35 @@ export class DidactWebviewPanel {
 			}
 		}
 	}
-	
-	getCachedHTML() : string | undefined {
+
+	getFileContentsFromCache(filename : string) : string | undefined {
 		if (DidactWebviewPanel.context) {
-			const cachePath = path.join(DidactWebviewPanel.context.globalStoragePath, `didact/cache`);
-			const htmlFilePath = path.join(cachePath, 'currentHtml.html');
-			try {
-				if (fs.existsSync(htmlFilePath)) {
-					let contents = fs.readFileSync(htmlFilePath);
-					return contents.toLocaleString();
+			const cachePath = path.join(DidactWebviewPanel.context.globalStoragePath, DidactWebviewPanel.didactCachePath);
+			if (cachePath) {
+				const filePath = path.join(cachePath, filename);
+				try {
+					if (fs.existsSync(filePath)) {
+						let contents = fs.readFileSync(filePath);
+						return contents.toLocaleString();
+					}
+				} catch (error) {
+					console.error(error);
 				}
-			} catch (error) {
-				console.error(error);
 			}
 		}
 		return undefined;
 	}
+	
+	getCachedHTML() : string | undefined {
+		return this.getFileContentsFromCache(DidactWebviewPanel.didactCacheHtmlFile);
+	}
 
 	getCachedTitle() : string | undefined {
-		if (DidactWebviewPanel.context) {
-			const cachePath : string = path.join(DidactWebviewPanel.context.globalStoragePath, `didact/cache`);
-			const titleFilePath : string = path.join(cachePath, 'currentTitle.txt');
-			try {
-				if (fs.existsSync(titleFilePath)) {
-					return fs.readFileSync(titleFilePath).toLocaleString();
-				}
-			} catch (error) {
-				console.error(error);
-			}
-		}
-		return undefined;
+		return this.getFileContentsFromCache(DidactWebviewPanel.didactCacheTitleFile);
+	}
+
+	public getCachedUri() : string | undefined {
+		return this.getFileContentsFromCache(DidactWebviewPanel.didactCacheUriFile);
 	}
 
 	getFirstHeadingText() : string | undefined {

--- a/src/didactWebView.ts
+++ b/src/didactWebView.ts
@@ -152,15 +152,16 @@ export class DidactWebviewPanel {
 			}
 		);
 
-
 		DidactWebviewPanel.currentPanel = new DidactWebviewPanel(panel, extensionPath);
 		if (inpath) {
 			DidactWebviewPanel.currentPanel.setDidactUriPath(inpath);
 		}
+		DidactWebviewPanel.currentPanel.setActiveContext(true);
 	}
 
 	public static revive(panel: vscode.WebviewPanel, extensionPath: string) {
 		DidactWebviewPanel.currentPanel = new DidactWebviewPanel(panel, extensionPath);
+		DidactWebviewPanel.currentPanel.setActiveContext(true);
 	}
 
 	public static async postMessage(message: string) {
@@ -201,6 +202,10 @@ export class DidactWebviewPanel {
 
 	public static async postCollectAllCommandIdsMessage() {
 		DidactWebviewPanel.postNamedSimpleMessage("returnCommands");
+	}
+
+	public setActiveContext(value: boolean) {
+		vscode.commands.executeCommand('setContext', 'didact.webview', value);
 	}
 
 	private constructor(panel: vscode.WebviewPanel, extensionPath: string) {

--- a/src/doublyLinkedList.ts
+++ b/src/doublyLinkedList.ts
@@ -1,0 +1,83 @@
+// found this here - https://www.cnblogs.com/answer1215/p/7623103.html
+
+/**
+ * Linked list node
+ */
+export interface DoublyLinkedListNode<T> {
+	value: T;
+	next?: DoublyLinkedListNode<T>;
+	prev?: DoublyLinkedListNode<T>;
+}
+
+/**
+ * Linked list for items of type T
+ */
+export class DoublyLinkedList<T> {
+	public head?: DoublyLinkedListNode<T> = undefined;
+	public tail?: DoublyLinkedListNode<T> = undefined;
+
+	/**
+	* Adds an item in O(1)
+	**/
+	add(value: T) {
+		const node: DoublyLinkedListNode<T> = {
+			value,
+			next: undefined,
+			prev: undefined,
+		};
+
+		if (!this.head) {
+			this.head = node;
+		}
+		if (this.tail) {
+			this.tail.next = node;
+			node.prev = this.tail;
+		}
+		this.tail = node;
+	}
+  
+	/**
+	* FIFO removal in O(1)
+	*/
+	dequeue(): T | undefined {
+		if (this.head) {
+			const value = this.head.value;
+			this.head = this.head.next;
+			if (!this.head) {
+				this.tail = undefined;
+			}
+			else {
+			this.head.prev = undefined;
+			}
+			return value;
+		}
+	}
+  
+	/**
+	 * LIFO removal in O(1)
+	 */
+	pop(): T | undefined {
+		if (this.tail) {
+			const value = this.tail.value;
+			this.tail = this.tail.prev;
+			if (!this.tail) {
+				this.head = undefined;
+			}
+			else {
+				this.tail.next = undefined;
+			}
+			return value;
+		}
+	}
+
+	/**
+	 * Returns an iterator over the values
+	 */
+	*values() {
+		let current = this.head;
+		while (current) {
+			yield current.value;
+			current = current.next;
+		}
+	}
+}

--- a/src/doublyLinkedList.ts
+++ b/src/doublyLinkedList.ts
@@ -19,7 +19,7 @@ export class DoublyLinkedList<T> {
 	/**
 	* Adds an item in O(1)
 	**/
-	add(value: T) {
+	push(value: T) {
 		const node: DoublyLinkedListNode<T> = {
 			value,
 			next: undefined,
@@ -35,7 +35,7 @@ export class DoublyLinkedList<T> {
 		}
 		this.tail = node;
 	}
-  
+
 	/**
 	* FIFO removal in O(1)
 	*/
@@ -45,14 +45,13 @@ export class DoublyLinkedList<T> {
 			this.head = this.head.next;
 			if (!this.head) {
 				this.tail = undefined;
-			}
-			else {
-			this.head.prev = undefined;
+			} else {
+				this.head.prev = undefined;
 			}
 			return value;
 		}
 	}
-  
+
 	/**
 	 * LIFO removal in O(1)
 	 */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,6 +58,8 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand(commandConstants.VALIDATE_COMMAND_IDS, extensionFunctions.validateCommandIDsInSelectedFile));
 	context.subscriptions.push(vscode.commands.registerCommand(commandConstants.TEXT_TO_CLIPBOARD_COMMAND, extensionFunctions.placeTextOnClipboard));
 	context.subscriptions.push(vscode.commands.registerCommand(commandConstants.COPY_FILE_URL_TO_WORKSPACE_COMMAND, extensionFunctions.copyFileFromURLtoLocalURI));
+	context.subscriptions.push(vscode.commands.registerCommand(commandConstants.HISTORY_BACK_COMMAND, extensionFunctions.historyBack));
+	context.subscriptions.push(vscode.commands.registerCommand(commandConstants.HISTORY_FORWARD_COMMAND, extensionFunctions.historyForward));
 
 	// set up the vscode URI handler
 	vscode.window.registerUriHandler({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,6 +60,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand(commandConstants.COPY_FILE_URL_TO_WORKSPACE_COMMAND, extensionFunctions.copyFileFromURLtoLocalURI));
 	context.subscriptions.push(vscode.commands.registerCommand(commandConstants.HISTORY_BACK_COMMAND, extensionFunctions.historyBack));
 	context.subscriptions.push(vscode.commands.registerCommand(commandConstants.HISTORY_FORWARD_COMMAND, extensionFunctions.historyForward));
+	context.subscriptions.push(vscode.commands.registerCommand(commandConstants.HISTORY_CLEAR, extensionFunctions.clearHistory));
 
 	// set up the vscode URI handler
 	vscode.window.registerUriHandler({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,6 +119,9 @@ export async function activate(context: vscode.ExtensionContext) {
 	if (openAtStartup) {
 		await extensionFunctions.openDidactWithDefault();
 	}
+
+	// workaround to retrieve cached Uri for last didact opened at session shutdown
+	extensionFunctions.addCachedDidactUriToHistory();
 }
 
 function createIntegrationsView(): void {

--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -306,7 +306,17 @@ export namespace extensionFunctions {
 		return out;
 	}
 
-	function addToHistory(uri:vscode.Uri | undefined) {
+	export function addCachedDidactUriToHistory() {
+		if (DidactWebviewPanel.currentPanel) {
+			let stashedUri = DidactWebviewPanel.currentPanel.getCachedUri();
+			if (stashedUri) {
+				let realUri = vscode.Uri.parse(stashedUri);
+				extensionFunctions.addToHistory(realUri);
+			}
+		}
+	}
+
+	export function addToHistory(uri:vscode.Uri | undefined) {
 		if (uri) {
 			historyList.add(uri);
 			console.log(Array.from(historyList.getList().values()));
@@ -850,7 +860,7 @@ export namespace extensionFunctions {
 		if (DidactWebviewPanel.currentPanel) {
 			let value = historyList.getPrevious()?.value;
 			if (value) {
-				startDidact(value);
+				startDidact(vscode.Uri.parse(value));
 			}
 		}
 	}
@@ -860,7 +870,7 @@ export namespace extensionFunctions {
 		if (DidactWebviewPanel.currentPanel) {
 			let value = historyList.getNext()?.value;
 			if (value) {
-				startDidact(value);
+				startDidact(vscode.Uri.parse(value));
 			}
 		}
 	}

--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -316,10 +316,14 @@ export namespace extensionFunctions {
 		}
 	}
 
+	// exposed for testing
+	export function getHistory() : DidactHistory {
+		return historyList;
+	}
+
 	export function addToHistory(uri:vscode.Uri | undefined) {
 		if (uri) {
 			historyList.add(uri);
-			console.log(Array.from(historyList.getList().values()));
 		}		
 	}
 

--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -61,6 +61,7 @@ export const TEXT_TO_CLIPBOARD_COMMAND = 'vscode.didact.copyToClipboardCommand';
 export const COPY_FILE_URL_TO_WORKSPACE_COMMAND = 'vscode.didact.copyFileURLtoWorkspaceCommand';
 export const HISTORY_BACK_COMMAND = 'vscode.didact.historyBack';
 export const HISTORY_FORWARD_COMMAND = 'vscode.didact.historyForward';
+export const HISTORY_CLEAR = 'vscode.didact.clearHistory';
 
 export const DIDACT_OUTPUT_CHANNEL = 'Didact Activity';
 
@@ -860,22 +861,29 @@ export namespace extensionFunctions {
 	}
 
 	export async function historyBack() : Promise<void> {
-		sendTextToOutputChannel(`Moving back through the Webview history one entry`);
+		sendTextToOutputChannel(`Moving back through the Didact history one entry`);
 		if (DidactWebviewPanel.currentPanel) {
 			let value = historyList.getPrevious()?.value;
 			if (value) {
-				startDidact(vscode.Uri.parse(value));
+				await startDidact(vscode.Uri.parse(value));
 			}
 		}
 	}
 
 	export async function historyForward() : Promise<void> {
-		sendTextToOutputChannel(`Moving forward through the Webview history one entry`);
+		sendTextToOutputChannel(`Moving forward through the Didact history one entry`);
 		if (DidactWebviewPanel.currentPanel) {
 			let value = historyList.getNext()?.value;
 			if (value) {
-				startDidact(vscode.Uri.parse(value));
+				await startDidact(vscode.Uri.parse(value));
 			}
+		}
+	}
+
+	export function clearHistory() {
+		sendTextToOutputChannel(`Clearing the Didact history`);
+		if (DidactWebviewPanel.currentPanel) {
+			historyList.clearHistory();
 		}
 	}
 }

--- a/src/history.ts
+++ b/src/history.ts
@@ -49,4 +49,10 @@ export class DidactHistory {
 			console.log(error);
 		}
 	}
+
+	// for testing purposes
+	public clearHistory() {
+		this.list = new DoublyLinkedList<string>();
+		this.current = undefined;
+	}
 }

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,0 +1,45 @@
+import { DoublyLinkedList, DoublyLinkedListNode } from "./doublyLinkedList";
+import { Uri } from 'vscode';
+
+export class DidactHistory {
+	private list = new DoublyLinkedList<Uri>();
+	private current : DoublyLinkedListNode<Uri> | undefined;
+
+	public add(uri : Uri) {
+		if (!this.uriAlreadyExists(uri)) {
+			this.list.add(uri);
+			this.current = this.list.tail;
+		}
+	}
+
+	public getCurrent() : DoublyLinkedListNode<Uri> | undefined {
+		console.log(`Current: ${this.current?.value}`);
+		return this.current;
+	}
+
+	public getPrevious() : DoublyLinkedListNode<Uri> | undefined {
+		const toReturn : DoublyLinkedListNode<Uri> | undefined = this.current?.prev;
+		this.current = toReturn;
+		return toReturn;
+	}
+
+	public getNext() : DoublyLinkedListNode<Uri> | undefined {
+		const toReturn : DoublyLinkedListNode<Uri> | undefined = this.current?.next;
+		this.current = toReturn;
+		return toReturn;
+	}
+
+	public getList() : DoublyLinkedList<Uri> {
+		return this.list;
+	}
+
+	private uriAlreadyExists(uri : Uri | undefined) : boolean | undefined{
+		try {
+			if (uri) {
+				return Array.from(this.list.values()).includes(uri);
+			}
+		} catch (error) {
+			console.log(error);
+		}
+	}
+}

--- a/src/history.ts
+++ b/src/history.ts
@@ -2,47 +2,48 @@ import { DoublyLinkedList, DoublyLinkedListNode } from "./doublyLinkedList";
 import { Uri } from 'vscode';
 
 export class DidactHistory {
-	private list = new DoublyLinkedList<Uri>();
-	private current : DoublyLinkedListNode<Uri> | undefined;
+	private list = new DoublyLinkedList<string>();
+	private current : DoublyLinkedListNode<string> | undefined;
 
 	public add(uri : Uri) {
-		if (!this.uriAlreadyExists(uri)) {
-			this.list.add(uri);
+		if (!this.uriAlreadyExists(uri.toString())) {
+			this.list.add(uri.toString());
 			this.current = this.list.tail;
 		}
 	}
 
-	public getCurrent() : DoublyLinkedListNode<Uri> | undefined {
-		console.log(`Current: ${this.current?.value}`);
+	public getCurrent() : DoublyLinkedListNode<string> | undefined {
 		return this.current;
 	}
 
-	public getPrevious() : DoublyLinkedListNode<Uri> | undefined {
-		let toReturn : DoublyLinkedListNode<Uri> | undefined = this.current?.prev;
-		// if (toReturn === this.list.head) {
-		// 	toReturn = this.list.tail;
-		// }
+	public getPrevious() : DoublyLinkedListNode<string> | undefined {
+		let toReturn : DoublyLinkedListNode<string> | undefined = this.current?.prev;
+		if (this.current === this.list.head) {
+			toReturn = this.list.tail;
+		}
 		this.current = toReturn;
 		return toReturn;
 	}
 
-	public getNext() : DoublyLinkedListNode<Uri> | undefined {
-		let toReturn : DoublyLinkedListNode<Uri> | undefined = this.current?.next;
-		// if (toReturn === this.list.tail) {
-		// 	toReturn = this.list.head;
-		// }
+	public getNext() : DoublyLinkedListNode<string> | undefined {
+		let toReturn : DoublyLinkedListNode<string> | undefined = this.current?.next;
+		if (this.current === this.list.tail) {
+			toReturn = this.list.head;
+		}
 		this.current = toReturn;
 		return toReturn;
 	}
 
-	public getList() : DoublyLinkedList<Uri> {
+	public getList() : DoublyLinkedList<string> {
 		return this.list;
 	}
 
-	private uriAlreadyExists(uri : Uri | undefined) : boolean | undefined{
+	private uriAlreadyExists(uri : string | undefined) : boolean | undefined{
 		try {
 			if (uri) {
-				return Array.from(this.list.values()).includes(uri);
+				let vals = Array.from(this.getList().values());
+				let index = vals.indexOf(uri);
+				return index > -1;
 			}
 		} catch (error) {
 			console.log(error);

--- a/src/history.ts
+++ b/src/history.ts
@@ -18,13 +18,19 @@ export class DidactHistory {
 	}
 
 	public getPrevious() : DoublyLinkedListNode<Uri> | undefined {
-		const toReturn : DoublyLinkedListNode<Uri> | undefined = this.current?.prev;
+		let toReturn : DoublyLinkedListNode<Uri> | undefined = this.current?.prev;
+		// if (toReturn === this.list.head) {
+		// 	toReturn = this.list.tail;
+		// }
 		this.current = toReturn;
 		return toReturn;
 	}
 
 	public getNext() : DoublyLinkedListNode<Uri> | undefined {
-		const toReturn : DoublyLinkedListNode<Uri> | undefined = this.current?.next;
+		let toReturn : DoublyLinkedListNode<Uri> | undefined = this.current?.next;
+		// if (toReturn === this.list.tail) {
+		// 	toReturn = this.list.head;
+		// }
 		this.current = toReturn;
 		return toReturn;
 	}

--- a/src/history.ts
+++ b/src/history.ts
@@ -7,7 +7,7 @@ export class DidactHistory {
 
 	public add(uri : Uri) {
 		if (!this.uriAlreadyExists(uri.toString())) {
-			this.list.add(uri.toString());
+			this.list.push(uri.toString());
 			this.current = this.list.tail;
 		}
 	}

--- a/src/test/suite/extensionFunctions.test.ts
+++ b/src/test/suite/extensionFunctions.test.ts
@@ -216,6 +216,22 @@ suite('Extension Functions Test Suite', () => {
 		expect(extensionFunctions.getHistory().getPrevious()?.value).to.equal(uriOne);
 	});
 
+	test('test adding to history and clearing it', function() {
+		console.log('clear history for test');
+		extensionFunctions.getHistory().clearHistory();
+		expect(Array.from(extensionFunctions.getHistory().getList().values()).length).to.equal(0);
+
+		let one : vscode.Uri = vscode.Uri.parse(uriOne);
+		console.log(`add uri - ${uriOne}`);
+		extensionFunctions.addToHistory(one);
+		expect(Array.from(extensionFunctions.getHistory().getList().values()).length).to.equal(1);
+
+		console.log(`clear history via command function`);
+		extensionFunctions.clearHistory();
+		expect(Array.from(extensionFunctions.getHistory().getList().values()).length).to.equal(0);
+	});
+
+
 });
 
 function checkCanParseDidactUriForPath(urlValue: string, endToCheck: string, alternateEnd : string) {


### PR DESCRIPTION
Adds a very basic history to the Didact window. It re-opens the files and is not caching the HTML, but does cache the URIs used. Note that the cache is reset to the last didact file opened at workspace closing time if it is available. Otherwise, the history is empty each time the workspace starts. 

To test:
* open a few didact files from the didact view
* use ctrl+shift+left to go back in the history (it loops back from the first item to the last)
* use ctrl+shift+right to go forward in the history (it loops forward from the last item to the first)
* leave a didact file open, close the workspace
* reopen the workspace, add a different didact, the cached didact file should be first in the history

![image](https://user-images.githubusercontent.com/530878/90698339-aeb1ed00-e23d-11ea-904b-0072a797c640.png)
