### PR TITLE
Fusetools2 804 fixing asciidoc includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the "vscode-didact" extension will be documented in this 
 
 ## 0.1.18
 
- - 
+ - Added fix to support AsciiDoc include statements. Any adoc include files must be in a location relative to the file in which they are included. [FUSETOOLS2-804](https://issues.redhat.com/browse/FUSETOOLS2-804)
 
 ## 0.1.17
 

--- a/src/asciidocUtils.ts
+++ b/src/asciidocUtils.ts
@@ -23,24 +23,22 @@ export function getADParser(): any {
 
 export function parseADtoHTML(content: string, baseDir?: string): any {
 	// note: base_dir is required to handle adoc includes
-	const opts1 = { 
-		safe: 'safe',
-		'base_dir': baseDir,
-		'attributes': {
-			'showtitle': true,
-			'icons': 'font'
-	}};
-	const opts2 = { 
-		safe: 'safe',
-		'attributes': {
-			'showtitle': true,
-			'icons': 'font'
-	}};
 	if (baseDir) {
-		const html = asciidoctor.convert(content, opts1);
-		return html;
+		const optsWithBaseDir = { 
+			safe: 'safe',
+			'base_dir': baseDir,
+			'attributes': {
+				'showtitle': true,
+				'icons': 'font'
+		}};
+		return asciidoctor.convert(content, optsWithBaseDir);
 	} else {
-		const html = asciidoctor.convert(content, opts2);
-		return html;
+		const optsNoBaseDir = { 
+			safe: 'safe',
+			'attributes': {
+				'showtitle': true,
+				'icons': 'font'
+		}};
+		return asciidoctor.convert(content, optsNoBaseDir);
 	}
 }

--- a/src/asciidocUtils.ts
+++ b/src/asciidocUtils.ts
@@ -18,14 +18,29 @@
 const asciidoctor = require('asciidoctor')();
 
 export function getADParser(): any {
-    return asciidoctor;
+	return asciidoctor;
 }
 
-export function parseADtoHTML(content: string): any {
-    const html = asciidoctor.convert(content, { 'safe': 'server',
-        'attributes': {
-            'showtitle': true,
-            'icons': 'font'
-        } });
-    return html;
+export function parseADtoHTML(content: string, baseDir?: string): any {
+	// note: base_dir is required to handle adoc includes
+	const opts1 = { 
+		safe: 'safe',
+		'base_dir': baseDir,
+		'attributes': {
+			'showtitle': true,
+			'icons': 'font'
+	}};
+	const opts2 = { 
+		safe: 'safe',
+		'attributes': {
+			'showtitle': true,
+			'icons': 'font'
+	}};
+	if (baseDir) {
+		const html = asciidoctor.convert(content, opts1);
+		return html;
+	} else {
+		const html = asciidoctor.convert(content, opts2);
+		return html;
+	}
 }

--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -506,19 +506,25 @@ export function isAsciiDoc() : boolean {
 	return false;
 }
 
-// retrieve didact text from a file
-async function getDataFromFile(uri:vscode.Uri) : Promise<string|undefined> {
+// retrieve didact text from a file - exported for test
+export async function getDataFromFile(uri:vscode.Uri) : Promise<string|undefined> {
 	try {
 		const content = fs.readFileSync(uri.fsPath, 'utf8');
 		const extname = path.extname(uri.fsPath);
 		let result : string;
 		if (extname.localeCompare('.adoc') === 0) {
-			result = parseADtoHTML(content);
+			let baseDir : string | undefined = undefined;
+			if (uri.scheme.trim().startsWith('file')) {
+				baseDir = path.dirname(uri.fsPath);
+			}
+			result = parseADtoHTML(content, baseDir);
 			return result;
 		} else if (extname.localeCompare('.md') === 0) {
 			const parser = getMDParser();
 			result = parser.render(content);
 			return result;
+		} else {
+			throw new Error(`Unknown file type encountered: ${extname}`);
 		}
 	} catch (error) {
 		throw new Error(error);

--- a/src/test/data/include.asciidoc.txt
+++ b/src/test/data/include.asciidoc.txt
@@ -1,0 +1,6 @@
+== Included Section
+
+And here's some text from the included file. 
+
+The quick brown fox jumps over the lazy dog.
+ 

--- a/src/test/data/includetext.didact.adoc
+++ b/src/test/data/includetext.didact.adoc
@@ -1,0 +1,5 @@
+### Include Test
+
+Here's some text in the main file. 
+
+include::include.asciidoc.txt[]

--- a/src/test/suite/asciidocUtilsTest.test.ts
+++ b/src/test/suite/asciidocUtilsTest.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import * as vscode from 'vscode';
+import * as extensionFunctions from '../../extensionFunctions';
+import * as path from 'path';
+import { expect } from 'chai';
+import * as Utils from './Utils';
+
+suite('AsciiDoc Utils Test Suite', () => {
+
+	setup(() => {
+		Utils.ensureExtensionActivated();
+	});
+
+	test('open an asciidoc file', async () => {
+		const testFile = path.resolve(__dirname, '..', '..', '..', './demos/asciidoc/didact-demo.didact.adoc');
+		const content = await extensionFunctions.getDataFromFile(vscode.Uri.parse(testFile));
+		expect(content).to.not.equal(null);
+		expect(content).to.include('Ideas or want to contribute?');
+	});
+
+	test('open an asciidoc file with an include', async () => {
+		const testFile = path.resolve(__dirname, '..', '..', '..', './src/test/data/includetext.didact.adoc');
+		const content = await extensionFunctions.getDataFromFile(vscode.Uri.parse(testFile));
+		expect(content).to.not.equal(null);
+		expect(content).to.include('The quick brown fox jumps over the lazy dog.');
+	});
+
+});


### PR DESCRIPTION
Addresses the issue discovered by @pwright when adding AsciiDoc `include` directives. 

To define the use case: As a Didact tutorial developer using AsciiDoc, I want to be able to break up my Didact file and use `include` directives to pull multiple files into the final document that is rendered in the Didact webview.

A limitation at this point will be that if I have a Didact file with included files, those files will need to be in the directory alongside the main Didact.adoc file or in a folder relative to the path of the main Didact.adoc file.

So if I have a file structure like

```
project
│   root.didact.adoc
│   include1.adoc    
│
└───moreincludes
      │   include2.adoc
```

You could then include either of the following file references in root.didact.adoc

```
include::include1.adoc[]
include::moreincludes/include2.adoc[]
```

Note that a limitation of this approach is that  includes cannot be processed unless they are either local in the workspace or hosted in an extension so we have access to the file directory. The use of base_dir means we must have access to the root directory to use as the base for all file/folder-based include directives in the adoc file.