### PR TITLE
FUSETOOLS2-811 - adding a simple command to help structure didact links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1726,6 +1726,14 @@
 				}
 			}
 		},
+		"iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
+		},
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -2684,6 +2692,11 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
 		"seek-bzip": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
@@ -3084,6 +3097,14 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
 			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+		},
+		"urlencode": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/urlencode/-/urlencode-1.1.0.tgz",
+			"integrity": "sha1-HyuibwE8hfATP3o61v8nMK33y7c=",
+			"requires": {
+				"iconv-lite": "~0.4.11"
+			}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,10 @@
 				"command": "vscode.didact.clearHistory",
 				"title": "Didact: Clear History",
 				"when": "didact.webview"
+			},
+			{
+				"command": "vscode.didact.startLink",
+				"title": "Didact: Start Didact Link"
 			}
 		],
 		"keybindings": [
@@ -144,6 +148,12 @@
 				"key": "alt+up",
 				"mac": "alt+up",
 				"when": "didact.webview"
+			},
+			{
+				"command": "vscode.didact.startLink",
+				"key": "ctrl+shift+d",
+				"mac": "cmd+shift+d",
+				"when": "editorFocus && resourceFilename =~ /[.](didact)[.](md|adoc)$/"
 			}
 		],
 		"menus": {
@@ -241,6 +251,7 @@
 		"markdown-it-task-lists": "^2.1.1",
 		"node-fetch": "^2.6.1",
 		"tmp": "^0.2.1",
+		"urlencode": "^1.1.0",
 		"xmldom": "^0.3.0"
 	}
 }

--- a/src/didactPalette.ts
+++ b/src/didactPalette.ts
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import * as vscode from 'vscode';
+const urlencode = require('urlencode');
+
+// TODO: Leave this open to passing arguments in case we can use it also to edit
+// an existing didact link?
+export async function startDidactLink(...args: any[]): Promise<boolean> {
+	const activeEditor = vscode.window.activeTextEditor;
+	if (!activeEditor) {
+		throw new Error('No text editor open.');
+	}
+	
+	const vsCommands : string[] = await vscode.commands.getCommands(true);
+	const commandIdChoice: string | undefined = await vscode.window.showQuickPick(vsCommands, {
+		placeHolder: 'Select a VS Code command'
+	});
+	if (commandIdChoice) {
+		let didactLink =  `didact://?commandId=${commandIdChoice}`;
+		const hasCompletion = await addCompletion();
+		if (hasCompletion) {
+			didactLink += `&completion=${hasCompletion}`;
+		}
+		const hasError = await addError();
+		if (hasError) {
+			didactLink += `&error=${hasError}`;
+		}
+		insertText(didactLink);
+	} else {
+		throw new Error('No command selection made.');
+	}
+	return true;
+}
+
+async function askYesNo(msg: string) : Promise<string | undefined> {
+	const askQuestion: string | undefined = await vscode.window.showQuickPick(["Yes", "No"], {
+		placeHolder: msg
+	});
+	return askQuestion;
+}
+
+async function askForStringToUrlEncode(initialValue : string) : Promise<string | undefined> {
+	const result = await vscode.window.showInputBox({
+		value: initialValue
+	});
+	if (result) {
+		return urlencode(result);
+	}
+	return undefined;
+}
+
+async function addCompletion() : Promise<string | undefined> {
+	const hasCompletion: string | undefined = await askYesNo('Does this Didact action have a Completion message?');
+	if (hasCompletion && hasCompletion.toLocaleLowerCase() === 'yes') {
+		return await askForStringToUrlEncode('This action is complete');
+	}
+	return undefined;
+}
+
+async function addError() : Promise<string | undefined> {
+	const hasError: string | undefined = await askYesNo('Does this Didact action have an Error message?');
+	if (hasError && hasError.toLocaleLowerCase() === 'yes') {
+		return await askForStringToUrlEncode('An error occurred');
+	}
+	return undefined;
+}
+
+function insertText(newText : string) {
+	const activeEditor = vscode.window.activeTextEditor;
+	if (!activeEditor) { return; }
+	activeEditor.edit((selectedText) => {
+		selectedText.replace(activeEditor.selection, newText);
+	});
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import { registerTutorial, clearRegisteredTutorials, getOpenAtStartupSetting, cl
 import * as path from 'path';
 import {DidactUriCompletionItemProviderMarkdown} from './didactUriCompletionItemProviderMarkdown';
 import {DidactUriCompletionItemProviderAsciiDoc} from './didactUriCompletionItemProviderAsciiDoc';
+import {startDidactLink} from './didactPalette';
 
 const DIDACT_VIEW = 'didact.tutorials';
 
@@ -63,6 +64,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.OPEN_NAMED_OUTPUTCHANNEL_COMMAND, extensionFunctions.openNamedOutputChannel));
 	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.SEND_TO_NAMED_OUTPUTCHANNEL_COMMAND, extensionFunctions.sendTextToNamedOutputChannel));
 	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.FILE_TO_CLIPBOARD_COMMAND, extensionFunctions.copyFileTextToClipboard));
+	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.DIDACT_START_LINK, startDidactLink));
 
 	// set up the vscode URI handler
 	vscode.window.registerUriHandler({

--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -65,6 +65,7 @@ export const HISTORY_FORWARD_COMMAND = 'vscode.didact.historyForward';
 export const HISTORY_CLEAR = 'vscode.didact.clearHistory';
 export const DIDACT_OUTPUT_CHANNEL = 'Didact Activity';
 export const FILE_TO_CLIPBOARD_COMMAND = 'vscode.didact.copyFileTextToClipboardCommand';
+export const DIDACT_START_LINK = 'vscode.didact.startLink';
 
 const commandPrefix = 'didact://?commandId';
 // note that this MUST be also updated in the main.js file 


### PR DESCRIPTION
Signed-off-by: bfitzpat@redhat.com <bfitzpat@redhat.com>

Early beginnings of a palette-based UI for constructing Didact links.

![didact-palette-demo](https://user-images.githubusercontent.com/530878/96509320-10c8a780-1219-11eb-8d1e-a7e644d7cd1b.gif)

In this example, we have a simple Didact URI that calls a no-argument command (workbench.action.showCommands) and enables you to type the completion or error strings for the Uri and automatically URL encode them.

Ultimately we want to do more with the commands we contribute, but we don't have the nice Camel Catalog to pull from for the VS Code command set at this point so we can only do so much.

This is far from done, but a possible path.