### PR TITLE
FUSETOOLS2-832 - allow passing json parameter to commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the "vscode-didact" extension will be documented in this 
 ## 0.1.18
 
  - Added fix to support AsciiDoc include statements. Any adoc include files must be in a location relative to the file in which they are included. [FUSETOOLS2-804](https://issues.redhat.com/browse/FUSETOOLS2-804)
+ - Support json parameter for commands [FUSETOOLS2-832](https://issues.redhat.com/browse/FUSETOOLS2-832)
 
 ## 0.1.17
 

--- a/src/commandHandler.ts
+++ b/src/commandHandler.ts
@@ -100,6 +100,13 @@ export async function processInputs(incoming : string, extensionPath? : string) 
 					handleNumber(output, text);
 				}
 			}
+			
+			if (query.json) {
+				const text = getValue(query.json);
+				if (text) {
+					output.push(JSON.parse(text));
+				}
+			}
 
 			console.log(`commandId : ${commandId}`);
 			console.log(`output : ${output.toString()}`);


### PR DESCRIPTION
- missing tests
- need to determine if list of json needs to be handled similarly to text/user/number
- need to determine if it is a common practice

with that, we can use commands that are using json as arguments for instance:

`[rename terminal](didact://?commandId=workbench.action.terminal.renameWithArg&json=\{"name":"aNewName"\})`