### PR TITLE
FUSETOOLS2-742 - adding new open option for scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the "vscode-didact" extension will be documented in this 
  - Improved Didact code completion support. [FUSETOOLS2-811](https://issues.redhat.com/browse/FUSETOOLS2-811)
  - Added fix to support AsciiDoc include statements. Any adoc include files must be in a location relative to the file in which they are included. [FUSETOOLS2-804](https://issues.redhat.com/browse/FUSETOOLS2-804)
  - Support json parameter for commands [FUSETOOLS2-832](https://issues.redhat.com/browse/FUSETOOLS2-832)
+ - Added a new option when scaffolding files from json. Open = true will open the file in a new text editor [FUSETOOLS2-742](https://issues.redhat.com/browse/FUSETOOLS2-742)
 
 ## 0.1.17
 

--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -97,7 +97,7 @@ export function initialize(inContext: vscode.ExtensionContext): void {
 }
 
 // use the json to model the folder/file structure to be created in the vscode workspace
-export async function scaffoldProjectFromJson(jsonpath:vscode.Uri | undefined): Promise<void> {
+export async function scaffoldProjectFromJson(jsonpath:vscode.Uri): Promise<void> {
 	sendTextToOutputChannel(`Scaffolding project from json: ${jsonpath}`);
 	if (utils.getWorkspacePath()) {
 		let testJson : any;

--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -97,7 +97,7 @@ export function initialize(inContext: vscode.ExtensionContext): void {
 }
 
 // use the json to model the folder/file structure to be created in the vscode workspace
-export async function scaffoldProjectFromJson(jsonpath:vscode.Uri): Promise<void> {
+export async function scaffoldProjectFromJson(jsonpath:vscode.Uri | undefined): Promise<void> {
 	sendTextToOutputChannel(`Scaffolding project from json: ${jsonpath}`);
 	if (utils.getWorkspacePath()) {
 		let testJson : any;

--- a/src/scaffoldUtils.ts
+++ b/src/scaffoldUtils.ts
@@ -69,7 +69,7 @@ function isJson(item: any) {
 }
 
 // create the folder structure from the json project file
-export async function createFoldersFromJSON(json: any, jsonpath?: vscode.Uri): Promise<any> {
+export async function createFoldersFromJSON(json: any, jsonpath: vscode.Uri): Promise<any> {
 	try {
 		if (vscode.workspace.workspaceFolders === undefined || vscode.workspace.workspaceFolders.length === 0) {
 			throw new Error('No workspace folder. Workspace must have at least one folder before Didact scaffolding can begin. Add a folder, restart your workspace, and then try again.');
@@ -132,7 +132,7 @@ export async function createFoldersFromJSON(json: any, jsonpath?: vscode.Uri): P
 }
 
 // create any files specified in the project json file
-async function createFiles(folderNode: any, files: any, jsonpath?: vscode.Uri): Promise<any> {
+async function createFiles(folderNode: any, files: any, jsonpath: vscode.Uri): Promise<any> {
 	try {
 		if (files) {
 			files.forEach(async (file: any) => {
@@ -153,7 +153,7 @@ async function createFiles(folderNode: any, files: any, jsonpath?: vscode.Uri): 
 				} else {
 					throw new Error(`Unable to retrieve file content for ${completeFilePath}.`);
 				}
-				if (file.open) {
+				if (file.open && file.open as boolean === true) {
 					const fileUri = vscode.Uri.parse(completeFilePath);
 					await vscode.commands.executeCommand('vscode.open', fileUri, vscode.ViewColumn.Beside);
 				}
@@ -166,7 +166,7 @@ async function createFiles(folderNode: any, files: any, jsonpath?: vscode.Uri): 
 }
 
 // create any sub folders 
-async function createSubFolders(folderNode: any, folders: any, jsonpath?: vscode.Uri): Promise<any> {
+async function createSubFolders(folderNode: any, folders: any, jsonpath: vscode.Uri): Promise<any> {
 	try {
 		folders.forEach(async (folder: any) => {
 			const newFolderName = folder.name;

--- a/src/scaffoldUtils.ts
+++ b/src/scaffoldUtils.ts
@@ -41,13 +41,7 @@ export function createSampleProject(): JSON {
 						"files": [
 							{
 								"name": "simple.groovy",
-								"content": "from('timer:groovy?period=1s')\n\t.routeId('groovy')\n\t.setBody()\n\t.simple('Hello Camel K from ${routeId}')\n\t.to('log:info?showAll=false')\n",
-								"open" : true
-							},
-							{
-								"name": "anotherFile.txt",
-								"content": "some content\n",
-								"open" : true
+								"content": "from('timer:groovy?period=1s')\n\t.routeId('groovy')\n\t.setBody()\n\t.simple('Hello Camel K from ${routeId}')\n\t.to('log:info?showAll=false')\n"
 							}
 						]
 					}
@@ -146,7 +140,6 @@ async function createFiles(folderNode: any, files: any, jsonpath?: vscode.Uri): 
 				const completeFilePath = `${folderNode}/${newFileName}`;
 				let newFileContent = undefined;
 				console.log(`Creating ${completeFilePath}`);
-				let openFileByDefault = false;
 				if (file.content) {
 					newFileContent = file.content;
 				} else if (file.copy && jsonpath) {
@@ -154,16 +147,13 @@ async function createFiles(folderNode: any, files: any, jsonpath?: vscode.Uri): 
 					const filetocopy = path.join(relative, file.copy);
 					newFileContent = fs.readFileSync(filetocopy, 'utf8');
 				}
-				if (file.open) {
-					openFileByDefault = file.open;
-				}
 				if (newFileContent) {
 					// write to a new file
 					fs.writeFileSync(completeFilePath, newFileContent);
 				} else {
 					throw new Error(`Unable to retrieve file content for ${completeFilePath}.`);
 				}
-				if (openFileByDefault) {
+				if (file.open) {
 					const fileUri = vscode.Uri.parse(completeFilePath);
 					await vscode.commands.executeCommand('vscode.open', fileUri, vscode.ViewColumn.Beside);
 				}

--- a/src/test/data/scaffoldOpen.json
+++ b/src/test/data/scaffoldOpen.json
@@ -1,0 +1,28 @@
+{
+	"folders" : [
+	{
+		"name": "root",
+		"folders": [
+			{
+				"name": "src",
+				"files": [
+					{
+						"name": "simple.groovy",
+						"content": "from('timer:groovy?period=1s')\n\t.routeId('groovy')\n\t.setBody()\n\t.simple('Hello Camel K from ${routeId}')\n\t.to('log:info?showAll=false')\n",
+						"open" : true
+					},
+					{
+						"name": "anotherFile.txt",
+						"content": "some content\n",
+						"open" : false
+					},
+					{
+						"name": "aThirdFile.txt",
+						"content": "some additional content\n"
+					}
+				]
+			}
+		]
+	}
+]
+}

--- a/src/test/suite/didact.test.ts
+++ b/src/test/suite/didact.test.ts
@@ -111,41 +111,11 @@ suite('Didact test suite', () => {
 	});
 
 	test('Scaffold new project, test for standard file (no open)', async function () {
-		try {
-			await commandHandler.processInputs(testScaffoldOpen).then( async () => {
-				// test to make sure the other file, set to open: false in json, does not open
-				try {
-					await waitUntil(() => {
-						return findEditorForFile(`aThirdFile.txt`);
-					}, EDITOR_OPENED_TIMEOUT, 1000).then(() => {
-						assert.fail(`aThirdFile.txt was found opened in editor when it should not have been`);	
-					});
-				} catch (error) {
-					assert.ok(error);
-				}
-			});
-		} catch (error) {
-			assert.fail(error);
-		}
+		await testScaffoldProjectDoesNotOpenFile(`aThirdFile.txt`);
 	});
 
 	test('Scaffold new project, test for open: false file', async function () {
-		try {
-			await commandHandler.processInputs(testScaffoldOpen).then( async () => {
-				// test to make sure the other file, set to open: false in json, does not open
-				try {
-					await waitUntil(() => {
-						return findEditorForFile(`anotherFile.txt`);
-					}, EDITOR_OPENED_TIMEOUT, 1000).then(() => {
-						assert.fail(`anotherFile.txt was found opened in editor when it should not have been`);	
-					});
-				} catch (error) {
-					assert.ok(error);
-				}
-			});
-		} catch (error) {
-			assert.fail(error);
-		}
+		await testScaffoldProjectDoesNotOpenFile(`anotherFile.txt`);
 	});
 
 	test('Scaffold new project with a uri', async function () {
@@ -303,6 +273,24 @@ suite('Didact test suite', () => {
 		});
 	});
 });
+
+async function testScaffoldProjectDoesNotOpenFile(fileName: string) {
+	try {
+		await commandHandler.processInputs(testScaffoldOpen).then(async () => {
+			try {
+				await waitUntil(() => {
+					return findEditorForFile(fileName);
+				}, EDITOR_OPENED_TIMEOUT, 1000).then(() => {
+					assert.fail(`${fileName} was found opened in editor when it should not have been`);
+				});
+			} catch (error) {
+				assert.ok(error);
+			}
+		});
+	} catch (error) {
+		assert.fail(error);
+	}
+}
 
 function findEditorForFile(filename: string) : vscode.TextEditor | undefined {
 	if (vscode.window.visibleTextEditors && vscode.window.visibleTextEditors.length > 0) {

--- a/src/test/suite/didact.test.ts
+++ b/src/test/suite/didact.test.ts
@@ -40,7 +40,7 @@ const testReq = 'didact://?commandId=vscode.didact.requirementCheck&text=os-requ
 const testReqCli = 'didact://?commandId=vscode.didact.cliCommandSuccessful&text=maven-cli-return-status$$uname&completion=Didact%20is%20running%20on%20a%20Linux%20machine.';
 const testWS = 'didact://?commandId=vscode.didact.workspaceFolderExistsCheck&text=workspace-folder-status';
 const testScaffold = 'didact://?commandId=vscode.didact.scaffoldProject&extFilePath=redhat.vscode-didact/demos/projectwithdidactfile.json';
-const testScaffoldOpen = 'didact://?commandId=vscode.didact.scaffoldProject&srcFilePath=redhat.vscode-didact/src/test/data/scaffoldOpen.json';
+const testScaffoldOpen = 'didact://?commandId=vscode.didact.scaffoldProject&extFilePath=redhat.vscode-didact/src/test/data/scaffoldOpen.json';
 
 suite('Didact test suite', () => {
 

--- a/src/test/suite/didact.test.ts
+++ b/src/test/suite/didact.test.ts
@@ -96,7 +96,6 @@ suite('Didact test suite', () => {
 	test('Scaffold new project, test for open: true file', async function () {
 		try {
 			await commandHandler.processInputs(testScaffoldOpen).then( async () => {
-				// test to make sure the groovy file, set to open: true in json, actually opens
 				try {
 					await waitUntil(() => {
 						return findEditorForFile(`simple.groovy`);


### PR DESCRIPTION
Signed-off-by: bfitzpat@redhat.com <bfitzpat@redhat.com>

Essentially we just want to add an option to files specified in the json for project scaffolding. If open = true, we will open the file beside the currently open editor (or window) rather than overwrite any other text editor that might be open.

Adding `"open" : true` to a file entry in the project json will open it in a new text editor window in the "next" column beside the currently open file/editor. Note that if the option is unspecified, it defaults to "false". 

It would be good practice to only open one file during the process of scaffolding, but conceivably a scaffold file could open an indefinite number of files, each in a new text editor pane. 

![scaffolding-open-example](https://user-images.githubusercontent.com/530878/97921792-b3545080-1d18-11eb-8343-9bdd7b474c73.gif)
