### PR TITLE
FUSETOOLS2-845 fixing link matcher

### DIFF
--- a/src/didactUriCompletionItemProvider.ts
+++ b/src/didactUriCompletionItemProvider.ts
@@ -212,7 +212,7 @@ export class DidactUriCompletionItemProvider implements vscode.CompletionItemPro
 	// public for testing
 	public findMatchForCommandVariable(input: string): RegExpMatchArray | null {
 		if (input) {
-			const regex = /(?:\?commandId=*)([^&)]*)/g;
+			const regex = /(?:\?commandId=*)([^&[)]*)/g;
 			return regex.exec(input);
 		}
 		return null;
@@ -232,7 +232,7 @@ export class DidactUriCompletionItemProvider implements vscode.CompletionItemPro
 
 	public findMatchForLinkPrefix(input: string): RegExpMatchArray | null {
 		if (input) {
-			const regex = /(?:link:|\()/g;
+			const regex = /(?:link:|\()(\[)?/g;
 			try {
 				return input.match(regex);
 			} catch (error) {

--- a/src/test/suite/didactUriCompletionItemProvider.test.ts
+++ b/src/test/suite/didactUriCompletionItemProvider.test.ts
@@ -95,12 +95,33 @@ suite("Didact URI completion provider tests", function () {
 			"[my link](didact://?comma)",
 			"link:didact://?commandId=someCommand",
 			"link:didact",
-			"(didact://?commandId=vscode.didact.cliCommandSuccessful&text=cli-requirement-name$$echo%20text)"
+			"(didact://?commandId=vscode.didact.cliCommandSuccessful&text=cli-requirement-name$$echo%20text)",
+			"link:didact://?",
+			"link:didact://?commandId=",
 		];
 		suite('testing didact protocol matching against positive results', () => {
 			validValues.forEach(function(value:string){
 				test(`matched a didact protocol in ${value}`, () => {
 					const match = provider.findMatchForDidactPrefix(value);
+					expect(match).to.not.be.null;
+					expect(match).to.have.lengthOf(1)
+				});
+			});
+		});
+	});
+
+	test("that the link matcher returns some expected results for valid asciidoc link values", () => {
+		const validValues : Array<string> = [
+			"link:didact://?commandId=someCommand[Some text]",
+			"link:didact://?commandId=someCommand",
+			"link:didact",
+			"link:",
+			"link:[some text]"
+		];
+		suite('testing link matching against positive results', () => {
+			validValues.forEach(function(value:string){
+				test(`matched a didact protocol in link ${value}`, () => {
+					const match = provider.findMatchForLinkPrefix(value);
 					expect(match).to.not.be.null;
 					expect(match).to.have.lengthOf(1)
 				});


### PR DESCRIPTION
Problem was with regex pattern matching and testing of the `link:` style links for asciidoc. Tweaked the regex and added some tests. 

![fix-for-adoc-link-completion](https://user-images.githubusercontent.com/530878/98165399-12de6780-1ea3-11eb-8923-3ea6bba90b72.gif)


Signed-off-by: bfitzpat@redhat.com <bfitzpat@redhat.com>