### PR TITLE
FUSETOOLS2-874 - adding test for markdownutils

### DIFF
--- a/src/test/suite/markdownUtils.test.ts
+++ b/src/test/suite/markdownUtils.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import { expect } from 'chai';
+import * as mdUtils from '../../markdownUtils';
+
+suite('Markdown Utils Test Suite', () => {
+
+	test('get the markdown parser', () => {
+		expect(mdUtils.getMDParser()).to.not.be.null;
+	});
+
+});


### PR DESCRIPTION
"not covered by tests"
https://sonarcloud.io/code?id=vscode-didact&selected=vscode-didact%3Asrc%2FmarkdownUtils.ts

Signed-off-by: bfitzpat@redhat.com <bfitzpat@redhat.com>