### PR TITLE
FUSETOOLS2-920 - add didact icon to the tree

### DIFF
--- a/src/nodeProvider.ts
+++ b/src/nodeProvider.ts
@@ -16,6 +16,8 @@
  */
 import * as vscode from 'vscode';
 import * as utils from './utils';
+import * as extensionFunctions from './extensionFunctions';
+import * as path from 'path';
 
 export class DidactNodeProvider implements vscode.TreeDataProvider<TreeNode> {
 
@@ -147,7 +149,16 @@ export class TreeNode extends vscode.TreeItem {
 }
 
 export class TutorialNode extends TreeNode {
-	// empty
+	constructor(
+		type: string,
+		label: string,
+		uri: string | undefined,
+		collapsibleState: vscode.TreeItemCollapsibleState
+	) {
+		super(type, label, uri, collapsibleState);
+		const localIconPath = vscode.Uri.file(path.resolve(extensionFunctions.getContext().extensionPath, 'icon/logo.svg'));
+		this.iconPath = localIconPath;
+	}
 }
 
 function retrieveTreeItemName(selection: TreeNode) {


### PR DESCRIPTION
Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>

Follows up https://github.com/redhat-developer/vscode-didact/pull/331 and requires the logo.svg that is in that PR to show the icons in the tree. If the icon is missing from the extension folder, the icons do not show in the tree. 

![image](https://user-images.githubusercontent.com/530878/102132710-389b4c80-3e11-11eb-8b28-57926f70390a.png)
