### PR TITLE
FUSETOOLS-920 - adjusting bottom margin

### DIFF
--- a/media/webviewslim.css
+++ b/media/webviewslim.css
@@ -112,7 +112,7 @@ code{
 
 .tutorialContent {
   margin: 0 auto;
-  margin-bottom: 20px;
+  margin-bottom: 30px;
   overflow: auto;
   width: 90%;
 }


### PR DESCRIPTION
Discovered a slight bug with the layout of the footer cutting off the bottom of the text... 

Without the fix, you can see the bottom line of the tutorial gets cut off:
![image](https://user-images.githubusercontent.com/530878/102236050-4227c180-3eb0-11eb-8815-5b2fc3875ddd.png)

With the fix (adding 10px more): 
![image](https://user-images.githubusercontent.com/530878/102235956-258b8980-3eb0-11eb-9b8a-361a362275c1.png)


Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>