### PR TITLE
FUSETOOLS2-997 - add 25px pad to .tutorialContent to fix occluded last line

### DIFF
--- a/media/webviewslim.css
+++ b/media/webviewslim.css
@@ -115,6 +115,7 @@ code{
   margin-bottom: 30px;
   overflow: auto;
   width: 90%;
+  padding-bottom: 25px;
 }
 
 .didactFooter {


### PR DESCRIPTION
added `padding-bottom: 25px` to `.tutorialContent` CSS as described here https://www.freecodecamp.org/news/how-to-keep-your-footer-where-it-belongs-59c6aa05c59c/

The issue was that there wasn't enough padding in the middle. The page is structured like:

```
<head>...</head>
<body class="content">
   <div class="tutorialContent">
      ... tutorial content rendered from Markdown or AsciiDoc
   </div>
   <div class="didactFooter">...footer content...</div>
</body>
```

I had padding in the content CSS, but not in the tutorialContent CSS. So we were not quite adjusting the tutorialContent correctly.

Minor fix. 

Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>