### PR TITLE
FUSETOOLS2-996 - instead of erroring out, open terminal if it exists

### DIFF
--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -155,8 +155,10 @@ export async function startTerminal(...rest: any[]): Promise<void>{ //name:strin
 		}
 	}
 	if (name) {
-		if (findTerminal(name)) {
-			throw new Error(`Terminal ${name} already exists`);
+		const oldTerm = findTerminal(name);
+		if (oldTerm) {
+			oldTerm.show();
+			return;
 		}
 	}
 	let terminal : vscode.Terminal | undefined = undefined;


### PR DESCRIPTION
Initially we were throwing an error if we found a terminal that already exists (see https://github.com/redhat-developer/vscode-didact/blob/98080df3e0d47467b01f322ce066300feab32984/src/extensionFunctions.ts#L158)

Now we just show the terminal if it already exists, which is the gentler approach.

Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>