### PR TITLE
FUSETOOLS2-1014 - adding small delay

### DIFF
--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -182,7 +182,6 @@ export async function startTerminal(...rest: any[]): Promise<void>{ //name:strin
 export async function showAndSendText(terminal: vscode.Terminal, text:string): Promise<void> {
 	if (terminal) {
 		terminal.show();
-		utils.delay(100);
 		terminal.sendText(text);
 	}
 }

--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -182,6 +182,7 @@ export async function startTerminal(...rest: any[]): Promise<void>{ //name:strin
 export async function showAndSendText(terminal: vscode.Terminal, text:string): Promise<void> {
 	if (terminal) {
 		terminal.show();
+		utils.delay(100);
 		terminal.sendText(text);
 	}
 }

--- a/src/test/suite/stubDemoTutorial.test.ts
+++ b/src/test/suite/stubDemoTutorial.test.ts
@@ -21,6 +21,7 @@ import { START_DIDACT_COMMAND, sendTerminalText, gatherAllCommandsLinks, getCont
 import { didactManager } from '../../didactManager';
 import { DidactUri } from '../../didactUri';
 import { handleText } from '../../commandHandler';
+import { waitUntil } from 'async-wait-until';
 
 const testMD = Uri.parse('vscode://redhat.vscode-didact?extension=demos/markdown/didact-demo.didact.md');
 
@@ -76,14 +77,16 @@ async function validateSimpleTerminalResponse(terminalName : string, terminalTex
 	if (term) {
 		console.log(`-current terminal = ${term?.name}`);
 		await sendTerminalText(terminalName, terminalText);
-		await delay(delayTime);
-		const term2 = focusOnNamedTerminal(terminalName);
-		await delay(delayTime);
-		let result = await getTerminalOutput(terminalName);
-		console.log(`-validateSimpleTerminalResponse terminal output = ${result}`);
+	
+		const resultValue = await waitUntil(async () => {
+			focusOnNamedTerminal(terminalName);
+			const result = await getTerminalOutput(terminalName);
+			console.log(`-validateSimpleTerminalResponse terminal output = ${result}`);
+			return result.includes(terminalText);
+		}, 5000);
 
 		// we're just making sure we get something back and can see the text we put into the terminal
-		expect(result).to.include(terminalText);
+		expect(resultValue).to.be.true;
 		findAndDisposeTerminal(terminalName);
 	}
 }
@@ -95,12 +98,14 @@ async function validateTerminalResponse(terminalName : string, terminalText : st
 	if (term) {
 		console.log(`-current terminal = ${term?.name}`);
 		await sendTerminalText(terminalName, terminalText);
-		await delay(delayTime);
-		const term2 = focusOnNamedTerminal(terminalName);
-		await delay(delayTime);
-		let result = await getTerminalOutput(terminalName);
-		console.log(`-validateTerminalResponse terminal output = ${result}`);
-		expect(result).to.include(terminalResponse);
+
+		const resultValue = await waitUntil(async () => {
+			focusOnNamedTerminal(terminalName);
+			const result = await getTerminalOutput(terminalName);
+			console.log(`-validateSimpleTerminalResponse terminal output = ${result}`);
+			return result.includes(terminalResponse);
+		}, 5000);
+		expect(resultValue).to.be.true;
 		findAndDisposeTerminal(terminalName);
 	}
 }

--- a/src/test/suite/stubDemoTutorial.test.ts
+++ b/src/test/suite/stubDemoTutorial.test.ts
@@ -59,7 +59,7 @@ suite('stub out a tutorial', () => {
 								expect(outputs).length.to.be.at.least(2);
 								const terminalName = outputs[0];
 								const terminalString = outputs[1];
-								await validateSimpleTerminalResponse(terminalName, terminalString);
+								await validateTerminalResponse(terminalName, terminalString);
 							}
 						});
 					});
@@ -70,42 +70,23 @@ suite('stub out a tutorial', () => {
 
 });
 
-async function validateSimpleTerminalResponse(terminalName : string, terminalText : string) {
-	console.log(`validateSimpleTerminalResponse terminal ${terminalName} executing text ${terminalText}`);
+async function validateTerminalResponse(terminalName : string, terminalText : string, terminalResponse? : string) {
+	console.log(`validateTerminalResponse terminal ${terminalName} executing text ${terminalText}`);
 	const term = window.createTerminal(terminalName);
 	expect(term).to.not.be.null;
 	if (term) {
 		console.log(`-current terminal = ${term?.name}`);
 		await sendTerminalText(terminalName, terminalText);
-	
-		const resultValue = await waitUntil(async () => {
+			const resultValue = await waitUntil(async () => {
 			focusOnNamedTerminal(terminalName);
 			const result = await getTerminalOutput(terminalName);
-			console.log(`-validateSimpleTerminalResponse terminal output = ${result}`);
-			return result.includes(terminalText);
+			console.log(`-validateTerminalResponse terminal output = ${result}`);
+			if (terminalResponse) {
+				return result.includes(terminalResponse);
+			} else {
+				return result.includes(terminalText);
+			}
 		}, 5000);
-
-		// we're just making sure we get something back and can see the text we put into the terminal
-		expect(resultValue).to.be.true;
-		findAndDisposeTerminal(terminalName);
-	}
-}
-
-async function validateTerminalResponse(terminalName : string, terminalText : string, terminalResponse : string) {
-	console.log(`validateTerminalResponse terminal ${terminalName} executing text ${terminalText} and looking for response ${terminalResponse}`);
-	const term = window.createTerminal(terminalName);
-	expect(term).to.not.be.null;
-	if (term) {
-		console.log(`-current terminal = ${term?.name}`);
-		await sendTerminalText(terminalName, terminalText);
-
-		const resultValue = await waitUntil(async () => {
-			focusOnNamedTerminal(terminalName);
-			const result = await getTerminalOutput(terminalName);
-			console.log(`-validateSimpleTerminalResponse terminal output = ${result}`);
-			return result.includes(terminalResponse);
-		}, 5000);
-		expect(resultValue).to.be.true;
 		findAndDisposeTerminal(terminalName);
 	}
 }

--- a/src/test/suite/stubDemoTutorial.test.ts
+++ b/src/test/suite/stubDemoTutorial.test.ts
@@ -24,7 +24,7 @@ import { handleText } from '../../commandHandler';
 
 const testMD = Uri.parse('vscode://redhat.vscode-didact?extension=demos/markdown/didact-demo.didact.md');
 
-const delayTime = 1000;
+const delayTime = 1500;
 
 suite('stub out a tutorial', () => {
 


### PR DESCRIPTION
between show and send

This was needed to resolve a timing issue we repeatedly were seeing in https://github.com/redhat-developer/vscode-didact/pull/437/checks?check_run_id=1973172348:
```
   1) stub out a tutorial
       that we can send an echo command to the terminal and get the response:
     AssertionError: expected 'Windows PowerShell\r\nCopyright (C) Microsoft Corporation. All rights reserved.' to include 'Hello World echoTerminal'
  	at d:\a\vscode-didact\vscode-didact\out\test\suite\stubDemoTutorial.test.js:107:38
  	at Generator.next (<anonymous>)
  	at fulfilled (d:\a\vscode-didact\vscode-didact\out\test\suite\stubDemoTutorial.test.js:21:58)
  	at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>