### PR TITLE
FUSETOOLS2-1021 - fixing flaky windows test

### DIFF
--- a/src/test/suite/stubDemoTutorial.test.ts
+++ b/src/test/suite/stubDemoTutorial.test.ts
@@ -28,8 +28,6 @@ const testMD = Uri.parse('vscode://redhat.vscode-didact?extension=demos/markdown
 
 const delayTime = 1500;
 
-const WINDOWS: string = 'win32';
-
 suite('stub out a tutorial', () => {
 
 	test('that we can send an echo command to the terminal and get the response', async () => {
@@ -104,21 +102,6 @@ async function validateTerminalResponse(terminalName : string, terminalText : st
 }
 
 async function getActiveTerminalOutput() : Promise<string> {
-	const term = window.activeTerminal;
-	console.log(`-current terminal = ${term?.name}`);
-	await executeAndWait('workbench.action.terminal.selectAll');
-	await delay(delayTime);
-	await executeAndWait('workbench.action.terminal.copySelection');
-	await executeAndWait('workbench.action.terminal.clearSelection');	
-	const clipboard_content = await env.clipboard.readText();
-	return clipboard_content.trim();
-}
-
-async function getTerminalOutput(terminalName : string) : Promise<string> {
-	const terminal = getNamedTerminal(terminalName);
-	expect(terminal).to.not.be.undefined;
-	expect(terminal?.name).to.equal(terminalName);
-	focusOnNamedTerminal(terminalName);
 	const term = window.activeTerminal;
 	console.log(`-current terminal = ${term?.name}`);
 	await executeAndWait('workbench.action.terminal.selectAll');


### PR DESCRIPTION
Used the approach from @apupier here - https://github.com/redhat-developer/vscode-didact/pull/452 and made one change to ensure that we found the right active terminal. 

Number of successful repetitive builds: 3 
Then
```
SIGSEGV
Exit code:   SIGSEGV
Failed to run tests
```
Then...
Successful repetitions: 3

I think this may be the right combination. SIGSEGV we can't really account for since that's a system fault. 

Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>