### PR TITLE
FUSETOOLS2-1010 - removing unused import

### DIFF
--- a/src/didactPanel.ts
+++ b/src/didactPanel.ts
@@ -17,7 +17,7 @@
 
 import * as extensionFunctions from './extensionFunctions';
 import * as path from 'path';
-import { ViewColumn, WebviewPanel, Disposable, Uri, workspace, window, ExtensionContext, extensions } from 'vscode';
+import { ViewColumn, WebviewPanel, Disposable, Uri, workspace, window, ExtensionContext } from 'vscode';
 import { DIDACT_DEFAULT_URL } from './utils';
 import { DEFAULT_TITLE_VALUE, didactManager, VIEW_TYPE } from './didactManager';
 import * as commandHandler from './commandHandler';


### PR DESCRIPTION
Removed unused extensions import from didactPanel

https://sonarcloud.io/project/issues?fileUuids=AXdPCJCO1d9Oa98Oz9lC&id=vscode-didact&resolved=false&types=CODE_SMELL

Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>