### PR TITLE
FUSETOOLS2-1034 - tutorial registry updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to the "vscode-didact" extension will be documented in this 
 
 ## 0.4.0
 
-- `Didact Tutorials` view no longer clears and resets the registry of tutorials on startup each time
-- New setting enables turning off re-adding the default Didact tutorials on Startup
-- New command `Didact: Clear Tutorial Registry` will clear the entire tutorial registry (use at own risk!)
-- New right-click menu `Didact: Register Didact Tutorial` on Didact files in the Explorer view enables user-registered tutorials to appear in `Didact Tutorials` view
-- New right-click menu `Remove Didact Tutorial` on tutorials in `Didact Tutorials` view enables tutorial removal
+- Didact Tutorial Registry Improvements
+  - `Didact Tutorials` view no longer clears and resets the registry of tutorials on startup each time
+  - New setting enables turning off re-adding the default Didact tutorials on Startup
+  - New command `Didact: Clear Tutorial Registry` will clear the entire tutorial registry (use at own risk!)
+  - New right-click menu `Didact: Register Didact Tutorial` on Didact files in the Explorer view enables user-registered tutorials to appear in `Didact Tutorials` view
+  - New right-click menu `Remove Didact Tutorial` on tutorials in `Didact Tutorials` view enables tutorial removal
 
 ## 0.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to the "vscode-didact" extension will be documented in this 
 
 ## 0.3.3
 
-- TBD
+- `Didact Tutorials` view no longer clears and resets the registry of tutorials on startup each time
+- New setting enables turning off re-adding the default Didact tutorials on Startup
+- New command `Didact: Clear Tutorial Registry` will clear the entire tutorial registry (use at own risk!)
+- New right-click menu `Didact: Register Didact Tutorial` on Didact files in the Explorer view enables user-registered tutorials to appear in `Didact Tutorials` view
+- New right-click menu `Remove Didact Tutorial` on tutorials in `Didact Tutorials` view enables tutorial removal
 
 ## 0.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the "vscode-didact" extension will be documented in this file.
 
-## 0.3.3
+## 0.4.0
 
 - `Didact Tutorials` view no longer clears and resets the registry of tutorials on startup each time
 - New setting enables turning off re-adding the default Didact tutorials on Startup

--- a/examples/register-tutorial.project.json
+++ b/examples/register-tutorial.project.json
@@ -1,0 +1,8 @@
+{
+    "files": [
+        {
+            "name":"test.didact.md",
+            "content":"# Local Didact Tutorial\n\nThis is an example of a Didact file provided in a scaffolded project.\n\n- [ ] [Click here to open the simple.groovy file in the new sample project](didact://?commandId=vscode.open&projectFilePath=anotherProject/src/simple.groovy&completion=Opened%20the%20simple.groovy%20file)\n"
+        }
+    ]
+}

--- a/examples/registry.example.didact.md
+++ b/examples/registry.example.didact.md
@@ -16,7 +16,7 @@ The `Didact: Register Didact Tutorial` menu prompts you to enter the Tutorial Na
 
 ## *New* Setting to turn off adding default tutorials to Didact Tutorials view
 
-To change the default Didact file, access the settings (`File->Preferences->Settings`), type **Didact** and set the `Didact: Auto Add Default Tutorials`. This defaults to checked, automatically looking to see if the default tutorials exist on startup. If you remove them and don't want them to be re-added on startup, make sure this setting is unchecked.
+To change the default Didact file, access the settings [(`File->Preferences->Settings`)](didact://?commandId=workbench.action.openSettings), type **Didact** and set the `Didact: Auto Add Default Tutorials`. This defaults to checked, automatically looking to see if the default tutorials exist on startup. If you remove them and don't want them to be re-added on startup, make sure this setting is unchecked.
 
 ## *New* Removing tutorials via right-click `Remove Didact Tutorial` menu in Didact Tutorials view
 
@@ -26,6 +26,8 @@ Note that if the `Auto Add Default Tutorials` setting is checked, any default tu
 
 ## *New* Adding a Didact link to register a tutorial
 
-[Click here to create a new Didact file](didact://?commandId=vscode.didact.scaffoldProject&extFilePath=redhat.vscode-didact/examples/register-tutorial.project.json)
+We can even register a tutorial directly via a link if we have access to the URI of the file. 
 
-[Now let's register it with the Didact Tutorials view](didact://?commandId=vscode.didact.registry.addUri&projectFilePath=test.didact.md&&text=New%20Tutorial$$New%20Category)
+For example, if you [click here to create a new, simple Didact file called `test.didact.md`](didact://?commandId=vscode.didact.scaffoldProject&extFilePath=redhat.vscode-didact/examples/register-tutorial.project.json)...
+
+[You can register it with the Didact Tutorials view with this link.](didact://?commandId=vscode.didact.registry.addUri&projectFilePath=test.didact.md&&text=New%20Tutorial$$New%20Category)

--- a/examples/registry.example.didact.md
+++ b/examples/registry.example.didact.md
@@ -1,0 +1,31 @@
+# Managing Didact Tutorials
+
+We have always had a number of default tutorials that appear in the Didact Tutorials view, including `Didact Demo` and `Writing Your First Didact Tutorial`, but what happens if you want to add your own tutorials to the view?
+
+## Adding via VS Code Extension Startup
+
+You can create your own VS Code extension to register a new tutorial with the Didact Tutorials view. And we have written a Didact tutorial to help you do just that!
+
+If you look at the Didact Tutorials view, you should be able to find the `Didact` category and beneath that find `Creating a New Didact Tutorial Extension`. That will step you through creating the new extension and your Didact tutorial file, then registering the new file with the view. 
+
+## *New* Adding via right-click `Didact: Register Didact Tutorial` menu in Explorer
+
+With version 0.4.0, we have added a new menu option when right-clicking on a Didact file in the Explorer view. 
+
+The `Didact: Register Didact Tutorial` menu prompts you to enter the Tutorial Name and Tutorial Category values for your tutorial. When completed, the `Didact Tutorials` view refreshes and you should see your new tutorial appear in the list.
+
+## *New* Setting to turn off adding default tutorials to Didact Tutorials view
+
+To change the default Didact file, access the settings (`File->Preferences->Settings`), type **Didact** and set the `Didact: Auto Add Default Tutorials`. This defaults to checked, automatically looking to see if the default tutorials exist on startup. If you remove them and don't want them to be re-added on startup, make sure this setting is unchecked.
+
+## *New* Removing tutorials via right-click `Remove Didact Tutorial` menu in Didact Tutorials view
+
+In the `Didact Tutorials` view, right-click on a tutorial and select `Remove Didact Tutorial` to delete it. 
+
+Note that if the `Auto Add Default Tutorials` setting is checked, any default tutorials removed will be re-added to the tutorials list on startup. 
+
+## *New* Adding a Didact link to register a tutorial
+
+[Click here to create a new Didact file](didact://?commandId=vscode.didact.scaffoldProject&extFilePath=redhat.vscode-didact/examples/register-tutorial.project.json)
+
+[Now let's register it with the Didact Tutorials view](didact://?commandId=vscode.didact.registry.addUri&projectFilePath=test.didact.md&&text=New%20Tutorial$$New%20Category)

--- a/examples/registry.example.didact.md
+++ b/examples/registry.example.didact.md
@@ -8,23 +8,23 @@ You can create your own VS Code extension to register a new tutorial with the Di
 
 If you look at the Didact Tutorials view, you should be able to find the `Didact` category and beneath that find `Creating a New Didact Tutorial Extension`. That will step you through creating the new extension and your Didact tutorial file, then registering the new file with the view. 
 
-## *New* Adding via right-click `Didact: Register Didact Tutorial` menu in Explorer
+## Adding via right-click `Didact: Register Didact Tutorial` menu in Explorer
 
 With version 0.4.0, we have added a new menu option when right-clicking on a Didact file in the Explorer view. 
 
 The `Didact: Register Didact Tutorial` menu prompts you to enter the Tutorial Name and Tutorial Category values for your tutorial. When completed, the `Didact Tutorials` view refreshes and you should see your new tutorial appear in the list.
 
-## *New* Setting to turn off adding default tutorials to Didact Tutorials view
+## Setting to turn off adding default tutorials to Didact Tutorials view
 
 To change the default Didact file, access the settings [(`File->Preferences->Settings`)](didact://?commandId=workbench.action.openSettings), type **Didact** and set the `Didact: Auto Add Default Tutorials`. This defaults to checked, automatically looking to see if the default tutorials exist on startup. If you remove them and don't want them to be re-added on startup, make sure this setting is unchecked.
 
-## *New* Removing tutorials via right-click `Remove Didact Tutorial` menu in Didact Tutorials view
+## Removing tutorials via right-click `Remove Didact Tutorial` menu in Didact Tutorials view
 
 In the `Didact Tutorials` view, right-click on a tutorial and select `Remove Didact Tutorial` to delete it. 
 
 Note that if the `Auto Add Default Tutorials` setting is checked, any default tutorials removed will be re-added to the tutorials list on startup. 
 
-## *New* Adding a Didact link to register a tutorial
+## Adding a Didact link to register a tutorial
 
 We can even register a tutorial directly via a link if we have access to the URI of the file. 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
 	"name": "vscode-didact",
-	"version": "0.3.3",
+	"version": "0.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "0.3.3",
+			"version": "0.4.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/download": "^6.2.4",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,14 @@
 			{
 				"command": "vscode.didact.registry.clear",
 				"title": "Didact: Clear Tutorial Registry"
+			},
+			{
+				"command": "vscode.didact.registry.addUri",
+				"title": "Didact: Register Didact Tutorial"
+			},
+			{
+				"command": "vscode.didact.view.tutorial.remove",
+				"title": "Remove Didact Tutorial"
 			}
 		],
 		"keybindings": [
@@ -144,6 +152,11 @@
 					"command": "vscode.didact.scaffoldProject",
 					"when": "resourceExtname =~ /\\.json$/",
 					"group": "vscode.didact.group@2"
+				},
+				{
+					"command": "vscode.didact.registry.addUri",
+					"when": "resourceFilename =~ /[.](didact)[.](md|adoc)$/",
+					"group": "vscode.didact.group@1"
 				}
 			],
 			"view/item/context": [
@@ -155,6 +168,11 @@
 				{
 					"command": "vscode.didact.view.tutorial.open",
 					"group": "1",
+					"when": "view == didact.tutorials && viewItem == TutorialNode"
+				},
+				{
+					"command": "vscode.didact.view.tutorial.remove",
+					"group": "2",
 					"when": "view == didact.tutorials && viewItem == TutorialNode"
 				}
 			],

--- a/package.json
+++ b/package.json
@@ -64,6 +64,12 @@
 						"default": "false",
 						"description": "Automatically open the default Didact file at workspace startup",
 						"scope": "window"
+					},
+					"didact.autoAddDefaultTutorials": {
+						"type": "boolean",
+						"default": "true",
+						"description": "Automatically add the default Didact tutorials to the Didact Tutorials view at workspace startup if not already registered",
+						"scope": "window"
 					}
 				}
 			}
@@ -113,6 +119,10 @@
 			{
 				"command": "vscode.didact.refresh",
 				"title": "Didact: Refresh Current Didact Window"
+			},
+			{
+				"command": "vscode.didact.registry.clear",
+				"title": "Didact: Clear Tutorial Registry"
 			}
 		],
 		"keybindings": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Didact",
 	"description": "Didact Tutorial Tools for Visual Studio Code",
 	"license": "Apache-2.0",
-	"version": "0.3.3",
+	"version": "0.4.0",
 	"icon": "icon/logo.png",
 	"publisher": "redhat",
 	"preview": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,7 @@
 import * as vscode from 'vscode';
 import * as extensionFunctions from './extensionFunctions';
 import { DidactNodeProvider, TreeNode } from './nodeProvider';
-import { registerTutorialWithCategory, clearRegisteredTutorials, getOpenAtStartupSetting, clearOutputChannels } from './utils';
+import { registerTutorialWithCategory, clearRegisteredTutorials, getOpenAtStartupSetting, clearOutputChannels, registerTutorialWithJSON, getAutoInstallDefaultTutorialsSetting } from './utils';
 import { DidactUriCompletionItemProvider } from './didactUriCompletionItemProvider';
 import { DidactPanelSerializer } from './didactPanelSerializer';
 import { VIEW_TYPE } from './didactManager';
@@ -26,7 +26,7 @@ import { VIEW_TYPE } from './didactManager';
 const DIDACT_VIEW = 'didact.tutorials';
 
 export const DEFAULT_TUTORIAL_CATEGORY = "Didact";
-const DEFAULT_TUTORIAL_NAME = "Didact Demo";
+export const DEFAULT_TUTORIAL_NAME = "Didact Demo";
 
 export const didactTutorialsProvider = new DidactNodeProvider();
 let didactTreeView : vscode.TreeView<TreeNode>;
@@ -63,6 +63,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.PASTE_TO_EDITOR_FOR_FILE_COMMAND, extensionFunctions.pasteClipboardToEditorForFile));
 	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.PASTE_TO_NEW_FILE_COMMAND, extensionFunctions.pasteClipboardToNewTextFile));
 	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.REFRESH_DIDACT, extensionFunctions.refreshDidactWindow));
+	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.CLEAR_DIDACT_REGISTRY, clearRegisteredTutorials));
+	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.ADD_TUTORIAL_TO_REGISTRY, registerTutorialWithJSON));
 
 	// set up the vscode URI handler
 	vscode.window.registerUriHandler({
@@ -86,24 +88,25 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	// set up so we don't lose the webview contents each time it goes 'invisible' 
 	vscode.window.registerWebviewPanelSerializer(VIEW_TYPE, new DidactPanelSerializer(context));
 
-	// always clear the registry and let the extensions register as they are activated
-	await clearRegisteredTutorials();
+	// register the default tutorials if the setting is set to true
+	const installTutorialsAtStartup : boolean = getAutoInstallDefaultTutorialsSetting();
+	if (installTutorialsAtStartup) {
+		// register the default tutorial
+		const tutorialUri = vscode.Uri.file(context.asAbsolutePath('./demos/markdown/didact-demo.didact.md'));
+		await registerTutorialWithCategory(DEFAULT_TUTORIAL_NAME, tutorialUri.fsPath, DEFAULT_TUTORIAL_CATEGORY);
 
-	// register the default tutorial
-	const tutorialUri = vscode.Uri.file(context.asAbsolutePath('./demos/markdown/didact-demo.didact.md'));
-	await registerTutorialWithCategory(DEFAULT_TUTORIAL_NAME, tutorialUri.fsPath, DEFAULT_TUTORIAL_CATEGORY);
+		// register the tutorial for creating a new extension with a didact file
+		const tutorial2Uri = vscode.Uri.file(context.asAbsolutePath('./create_extension/create-new-tutorial-with-extension.didact.md'));
+		await registerTutorialWithCategory("Create a New Didact Tutorial Extension", tutorial2Uri.fsPath, DEFAULT_TUTORIAL_CATEGORY);
 
-	// register the tutorial for creating a new extension with a didact file
-	const tutorial2Uri = vscode.Uri.file(context.asAbsolutePath('./create_extension/create-new-tutorial-with-extension.didact.md'));
-	await registerTutorialWithCategory("Create a New Didact Tutorial Extension", tutorial2Uri.fsPath, DEFAULT_TUTORIAL_CATEGORY);
+		// register the javascript tutorial
+		const tutorial3Uri = vscode.Uri.file(context.asAbsolutePath('./demos/markdown/helloJS/helloJS.didact.md'));
+		await registerTutorialWithCategory("HelloWorld with JavaScript in Three Steps", tutorial3Uri.fsPath, DEFAULT_TUTORIAL_CATEGORY);
 
-	// register the javascript tutorial
-	const tutorial3Uri = vscode.Uri.file(context.asAbsolutePath('./demos/markdown/helloJS/helloJS.didact.md'));
-	await registerTutorialWithCategory("HelloWorld with JavaScript in Three Steps", tutorial3Uri.fsPath, DEFAULT_TUTORIAL_CATEGORY);
-
-	// register the didact tutorial
-	const tutorial4Uri = vscode.Uri.file(context.asAbsolutePath('./demos/markdown/tutorial/tutorial.didact.md'));
-	await registerTutorialWithCategory("Writing Your First Didact Tutorial", tutorial4Uri.fsPath, DEFAULT_TUTORIAL_CATEGORY);
+		// register the didact tutorial
+		const tutorial4Uri = vscode.Uri.file(context.asAbsolutePath('./demos/markdown/tutorial/tutorial.didact.md'));
+		await registerTutorialWithCategory("Writing Your First Didact Tutorial", tutorial4Uri.fsPath, DEFAULT_TUTORIAL_CATEGORY);
+	}
 
 	// create the view
 	createIntegrationsView();
@@ -127,7 +130,6 @@ function createIntegrationsView(): void {
 }
 
 export async function deactivate(): Promise<void> {
-	await clearRegisteredTutorials();
 	clearOutputChannels();
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,10 @@
 import * as vscode from 'vscode';
 import * as extensionFunctions from './extensionFunctions';
 import { DidactNodeProvider, TreeNode } from './nodeProvider';
-import { registerTutorialWithCategory, clearRegisteredTutorials, getOpenAtStartupSetting, clearOutputChannels, registerTutorialWithJSON, getAutoInstallDefaultTutorialsSetting } from './utils';
+import { registerTutorialWithCategory, clearRegisteredTutorials, getOpenAtStartupSetting, 
+	clearOutputChannels, registerTutorialWithJSON, getAutoInstallDefaultTutorialsSetting,
+	addNewTutorialWithNameAndCategoryForDidactUri, 
+	removeTutorialByNameAndCategory} from './utils';
 import { DidactUriCompletionItemProvider } from './didactUriCompletionItemProvider';
 import { DidactPanelSerializer } from './didactPanelSerializer';
 import { VIEW_TYPE } from './didactManager';
@@ -65,6 +68,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.REFRESH_DIDACT, extensionFunctions.refreshDidactWindow));
 	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.CLEAR_DIDACT_REGISTRY, clearRegisteredTutorials));
 	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.ADD_TUTORIAL_TO_REGISTRY, registerTutorialWithJSON));
+	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.ADD_TUTORIAL_URI_TO_REGISTRY, addNewTutorialWithNameAndCategoryForDidactUri));
+	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.REMOVE_TUTORIAL_BY_NAME_AND_CATEGORY_FROM_REGISTRY, removeTutorialByNameAndCategory));
 
 	// set up the vscode URI handler
 	vscode.window.registerUriHandler({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,3 +143,10 @@ export function refreshTreeview(): void {
 		didactTutorialsProvider.refresh();
 	}
 }
+
+export async function revealTreeItem(node: TreeNode) {
+	await vscode.commands.executeCommand('didact.tutorials.focus'); // open the tutorials view
+	if (didactTreeView && didactTreeView.visible === true) {
+		didactTreeView.reveal(node);
+	}
+}

--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -66,6 +66,8 @@ export const PASTE_TO_ACTIVE_EDITOR_COMMAND = 'vscode.didact.copyClipboardToActi
 export const PASTE_TO_EDITOR_FOR_FILE_COMMAND = 'vscode.didact.copyClipboardToEditorForFile';
 export const PASTE_TO_NEW_FILE_COMMAND = 'vscode.didact.copyClipboardToNewFile';
 export const REFRESH_DIDACT = 'vscode.didact.refresh';
+export const CLEAR_DIDACT_REGISTRY = 'vscode.didact.registry.clear';
+export const ADD_TUTORIAL_TO_REGISTRY = 'vscode.didact.registry.addJson';
 
 export const EXTENSION_ID = "redhat.vscode-didact";
 

--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -68,6 +68,8 @@ export const PASTE_TO_NEW_FILE_COMMAND = 'vscode.didact.copyClipboardToNewFile';
 export const REFRESH_DIDACT = 'vscode.didact.refresh';
 export const CLEAR_DIDACT_REGISTRY = 'vscode.didact.registry.clear';
 export const ADD_TUTORIAL_TO_REGISTRY = 'vscode.didact.registry.addJson';
+export const ADD_TUTORIAL_URI_TO_REGISTRY = 'vscode.didact.registry.addUri';
+export const REMOVE_TUTORIAL_BY_NAME_AND_CATEGORY_FROM_REGISTRY = 'vscode.didact.view.tutorial.remove';
 
 export const EXTENSION_ID = "redhat.vscode-didact";
 

--- a/src/nodeProvider.ts
+++ b/src/nodeProvider.ts
@@ -85,6 +85,16 @@ export class DidactNodeProvider implements vscode.TreeDataProvider<TreeNode> {
 		this._onDidChangeTreeData.fire(undefined);
 	}
 
+	public getParent(element : TreeNode) : TreeNode | undefined {
+		if (element instanceof TutorialNode) {
+			const tutorial = element as TutorialNode;
+			if (tutorial.category) {
+				return this.findCategoryNode(tutorial.category);
+			}
+		}
+		return undefined;
+	}
+
 	getTreeItem(node: TreeNode): vscode.TreeItem {
 		return node;
 	}
@@ -128,7 +138,29 @@ export class DidactNodeProvider implements vscode.TreeDataProvider<TreeNode> {
 		}
         return children;
 	}
+
+	findCategoryNode(category : string) : TreeNode | undefined {
+		const nodeToFind = new TreeNode(category, category, undefined, vscode.TreeItemCollapsibleState.Collapsed);
+		if (this.doesNodeExist(this.treeNodes, nodeToFind)) {
+			return nodeToFind;
+		}
+		return undefined;
+	}
 	
+	findTutorialNode(category : string, tutorialName : string ) : TreeNode | undefined {
+		const catNode = this.findCategoryNode(category);
+		if (catNode) {
+			const treeItems : TreeNode[] = this.getChildren(catNode);
+			let foundNode : TreeNode | undefined = undefined;
+			treeItems.forEach(element => {
+				if (element.label === tutorialName && element.category === category) {
+					foundNode = element;
+				}
+			});
+			return foundNode;
+		}
+		return undefined;
+	}
 }
 
 // simple tree node for our tutorials view

--- a/src/nodeProvider.ts
+++ b/src/nodeProvider.ts
@@ -103,7 +103,7 @@ export class DidactNodeProvider implements vscode.TreeDataProvider<TreeNode> {
         const categories : string[] | undefined = utils.getDidactCategories();
         if (categories) {
             for (const category of categories) {
-                const newNode = new TreeNode("string", category, undefined, vscode.TreeItemCollapsibleState.Collapsed);
+                const newNode = new TreeNode(category, category, undefined, vscode.TreeItemCollapsibleState.Collapsed);
                 if (!this.doesNodeExist(this.treeNodes, newNode)) {
                     this.addChild(newNode, true, this.treeNodes);
                 }
@@ -118,7 +118,7 @@ export class DidactNodeProvider implements vscode.TreeDataProvider<TreeNode> {
 			if (tutorials) {
 				for (const tutorial of tutorials) {
 					const tutUri : string | undefined = utils.getUriForDidactNameAndCategory(tutorial, category);
-					const newNode = new TutorialNode("string", tutorial, tutUri, vscode.TreeItemCollapsibleState.None);
+					const newNode = new TutorialNode(category, tutorial, tutUri, vscode.TreeItemCollapsibleState.None);
 					newNode.contextValue = 'TutorialNode';
 					if (!this.doesNodeExist(children, newNode)) {
 						this.addChild(newNode, true, children);
@@ -133,7 +133,7 @@ export class DidactNodeProvider implements vscode.TreeDataProvider<TreeNode> {
 
 // simple tree node for our tutorials view
 export class TreeNode extends vscode.TreeItem {
-	type: string;
+	category: string;
 	uri : string | undefined;
 
 	constructor(
@@ -143,19 +143,19 @@ export class TreeNode extends vscode.TreeItem {
 		collapsibleState: vscode.TreeItemCollapsibleState
 	) {
 		super(label, collapsibleState);
-		this.type = type;
+		this.category = type;
 		this.uri = uri;
 	}
 }
 
 export class TutorialNode extends TreeNode {
 	constructor(
-		type: string,
+		category: string,
 		label: string,
 		uri: string | undefined,
 		collapsibleState: vscode.TreeItemCollapsibleState
 	) {
-		super(type, label, uri, collapsibleState);
+		super(category, label, uri, collapsibleState);
 		const localIconPath = vscode.Uri.file(path.resolve(extensionFunctions.getContext().extensionPath, 'icon/logo.svg'));
 		this.iconPath = localIconPath;
 	}

--- a/src/test/suite/didactUriCompletionItemProvider.test.ts
+++ b/src/test/suite/didactUriCompletionItemProvider.test.ts
@@ -110,7 +110,7 @@ suite("Didact URI completion provider tests", function () {
 	test("that the command processing for a command prefix returns expected results", async () => {
 		const match = provider.findMatchForCommandVariable('didact://?commandId=vscode.didact.');
 		const completionList = await provider.processCommands(match);
-		expect(completionList.items).to.have.lengthOf(29)
+		expect(completionList.items).to.have.lengthOf(31)
 	});
 
 	test("that the command processing for one command returns one expected result", async () => {

--- a/src/test/suite/didactUriCompletionItemProvider.test.ts
+++ b/src/test/suite/didactUriCompletionItemProvider.test.ts
@@ -110,7 +110,7 @@ suite("Didact URI completion provider tests", function () {
 	test("that the command processing for a command prefix returns expected results", async () => {
 		const match = provider.findMatchForCommandVariable('didact://?commandId=vscode.didact.');
 		const completionList = await provider.processCommands(match);
-		expect(completionList.items).to.have.lengthOf(27)
+		expect(completionList.items).to.have.lengthOf(29)
 	});
 
 	test("that the command processing for one command returns one expected result", async () => {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -30,10 +30,6 @@ suite('Extension Test Suite', () => {
 
 	test('that the didact tutorial is registered in the tutorials view', async function () {
 
-		// assume that it was cleared in registry.test.ts and make sure we add it again to be sure
-		const tutorialUri = vscode.Uri.file(getContext().asAbsolutePath('./demos/markdown/didact-demo.didact.md'));
-		await registerTutorialWithCategory(DEFAULT_TUTORIAL_NAME, tutorialUri.fsPath, DEFAULT_TUTORIAL_CATEGORY);
-
 		const tutorialName = 'Writing Your First Didact Tutorial';
 		const existingRegistry : string[] | undefined = getRegisteredTutorials();
 		if (existingRegistry) {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,15 +1,16 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { getOpenAtStartupSetting, getRegisteredTutorials } from '../../utils';
-import { DEFAULT_TUTORIAL_CATEGORY } from '../../extension';
+import { getAutoInstallDefaultTutorialsSetting, getOpenAtStartupSetting, getRegisteredTutorials, registerTutorialWithCategory } from '../../utils';
+import { DEFAULT_TUTORIAL_CATEGORY, DEFAULT_TUTORIAL_NAME } from '../../extension';
 import { expect } from 'chai';
-import * as Utils from './Utils';
+import { ensureExtensionActivated } from './Utils';
+import { getContext } from '../../extensionFunctions';
 
 suite('Extension Test Suite', () => {
 	const extensionId = 'redhat.vscode-didact';
 
 	setup(() => {
-		Utils.ensureExtensionActivated();
+		ensureExtensionActivated();
 	});
 
 	test('vscode-didact extension should be present', function(done) {
@@ -27,7 +28,11 @@ suite('Extension Test Suite', () => {
 		}
 	});
 
-	test('that the didact tutorial is registered in the tutorials view', function () {
+	test('that the didact tutorial is registered in the tutorials view', async function () {
+
+		// assume that it was cleared in registry.test.ts and make sure we add it again to be sure
+		const tutorialUri = vscode.Uri.file(getContext().asAbsolutePath('./demos/markdown/didact-demo.didact.md'));
+		await registerTutorialWithCategory(DEFAULT_TUTORIAL_NAME, tutorialUri.fsPath, DEFAULT_TUTORIAL_CATEGORY);
 
 		const tutorialName = 'Writing Your First Didact Tutorial';
 		const existingRegistry : string[] | undefined = getRegisteredTutorials();
@@ -45,6 +50,16 @@ suite('Extension Test Suite', () => {
 				}
 			}
 			expect(match).to.be.true;
+		}
+	});
+
+	test('by default, didact setting to automatically install default tutorials at startup should be true', function () {
+		const installAtStartup : boolean = getAutoInstallDefaultTutorialsSetting();
+		console.log(`installAtStartup = ${installAtStartup}`);
+		if (installAtStartup === false) {
+			assert.fail('Install tutorials at startup setting should be true by default');
+		} else {
+			assert.ok('Install tutorials at startup setting is correctly set to true by default.');
 		}
 	});
 	

--- a/src/test/suite/registry.test.ts
+++ b/src/test/suite/registry.test.ts
@@ -106,10 +106,7 @@ suite('Didact registry test suite', () => {
 		};
 		
 		try {
-			await vscode.commands.executeCommand(ADD_TUTORIAL_TO_REGISTRY, tutorialJson).then( () => {
-				assert.ok('Registered via json');
-				return;
-			});
+			await vscode.commands.executeCommand(ADD_TUTORIAL_TO_REGISTRY, tutorialJson);
 		} catch (error) {
 			assert.fail('Failed to register via json: ' + error);
 		}

--- a/src/test/suite/registry.test.ts
+++ b/src/test/suite/registry.test.ts
@@ -2,7 +2,8 @@ import * as assert from 'assert';
 import {getRegisteredTutorials, getDidactCategories, getTutorialsForCategory, getUriForDidactNameAndCategory, registerTutorialWithCategory, clearRegisteredTutorials, registerTutorialWithArgs} from '../../utils';
 import {before} from 'mocha';
 import * as vscode from 'vscode';
-import { ADD_TUTORIAL_TO_REGISTRY, REGISTER_TUTORIAL } from '../../extensionFunctions';
+import { ADD_TUTORIAL_TO_REGISTRY, getContext, REGISTER_TUTORIAL } from '../../extensionFunctions';
+import { DEFAULT_TUTORIAL_CATEGORY, DEFAULT_TUTORIAL_NAME } from '../../extension';
 
 const name = 'new-tutorial';
 const category = 'some-category';
@@ -20,6 +21,13 @@ suite('Didact registry test suite', () => {
 	test('assert that clearing the registry made it empty', async () => {
 		const registry = getRegisteredTutorials();
 		assert.strictEqual(registry, undefined);
+
+		// clean up and add one demo tutorial back in
+		const tutorialUri = vscode.Uri.file(getContext().asAbsolutePath('./demos/markdown/didact-demo.didact.md'));
+		await registerTutorialWithCategory(DEFAULT_TUTORIAL_NAME, tutorialUri.fsPath, DEFAULT_TUTORIAL_CATEGORY);
+
+		const addRegistry = getRegisteredTutorials();
+		assert.notStrictEqual(addRegistry, undefined);
 	});
 
 	test('add to registry', async () => {

--- a/src/test/suite/registryWorkspace.test.ts
+++ b/src/test/suite/registryWorkspace.test.ts
@@ -68,14 +68,13 @@ suite('Tutorial Registry Test Suite', () => {
 			await vscode.commands.executeCommand(START_DIDACT_COMMAND, didactFileUri);
 			try {
 				const predicate = () => didactManager.active() != undefined;
-				await waitUntil(predicate, { timeout: EDITOR_OPENED_TIMEOUT, intervalBetweenAttempts: 1000 }).then(() => {
-					expect(didactManager.active()?.getCurrentTitle()).to.equal("Local Didact Tutorial");
-				});
+				await waitUntil(predicate, { timeout: EDITOR_OPENED_TIMEOUT, intervalBetweenAttempts: 1000 });
+				expect(didactManager.active()?.getCurrentTitle()).to.equal("Local Didact Tutorial");
 			} catch (error) {
-				assert.fail(error);
+				assert.fail("Failed to start the Didact file and validate the title");
 			}
 		} catch (error) {
-			assert.fail(error);
+			assert.fail("Failed to register, then start the Didact file");
 		}
 	});
 });

--- a/src/test/suite/registryWorkspace.test.ts
+++ b/src/test/suite/registryWorkspace.test.ts
@@ -32,8 +32,6 @@ const EDITOR_OPENED_TIMEOUT = 5000;
 
 suite('Tutorial Registry Test Suite', () => {
 
-	const uriToRemoteDidactAdoc = 'https://raw.githubusercontent.com/redhat-developer/vscode-didact/master/demos/asciidoc/simple-example.didact.adoc';
-
 	async function cleanFiles() {
 		const testWorkspace = path.resolve(__dirname, '..', '..', '..', './test Fixture with speci@l chars');
 		const foldersAndFilesToRemove: string[] = [

--- a/src/test/suite/registryWorkspace.test.ts
+++ b/src/test/suite/registryWorkspace.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 'use strict';
+ 
+import * as path from 'path';
+import { removeFilesAndFolders } from '../../utils';
+import * as commandHandler from '../../commandHandler';
+import * as assert from 'assert';
+import {didactTutorialsProvider} from '../../extension';
+import { beforeEach } from 'mocha';
+import * as vscode from 'vscode';
+import { expect } from 'chai';
+import {START_DIDACT_COMMAND} from '../../extensionFunctions';
+import { didactManager } from '../../didactManager';
+import { waitUntil } from 'async-wait-until';
+
+const EDITOR_OPENED_TIMEOUT = 5000;
+
+suite('Tutorial Registry Test Suite', () => {
+
+	const uriToRemoteDidactAdoc = 'https://raw.githubusercontent.com/redhat-developer/vscode-didact/master/demos/asciidoc/simple-example.didact.adoc';
+
+	async function cleanFiles() {
+		const testWorkspace = path.resolve(__dirname, '..', '..', '..', './test Fixture with speci@l chars');
+		const foldersAndFilesToRemove: string[] = [
+			'test.didact.md'
+		];
+		await removeFilesAndFolders(testWorkspace, foldersAndFilesToRemove);
+	}
+
+	beforeEach(async () => {
+		await cleanFiles();
+	});
+
+	test('create new didact file and register it as a tutorial in the view', async () => {
+		const didactUriToCreateFile = `didact://?commandId=vscode.didact.scaffoldProject&extFilePath=redhat.vscode-didact/examples/register-tutorial.project.json`;
+		const category = "New Category";
+		const tutorialName = "New Tutorial";
+		const fileName = "test.didact.md";
+		const didactUriToRegisterTutorial = `didact://?commandId=vscode.didact.registry.addUri&projectFilePath=${fileName}&&text=${encodeURI(tutorialName)}$$${encodeURI(category)}`;
+
+		try {
+			await vscode.commands.executeCommand('didact.tutorials.focus'); // open the tutorials view
+			await commandHandler.processInputs(didactUriToCreateFile);
+			await commandHandler.processInputs(didactUriToRegisterTutorial);
+			const catNode = didactTutorialsProvider.findCategoryNode(category);
+			expect(catNode).to.not.be.undefined;
+
+			const foundTutorial = didactTutorialsProvider.findTutorialNode(category, tutorialName);
+			expect(foundTutorial).to.not.be.undefined;
+			const didactFileUri = foundTutorial?.uri;
+			expect(didactFileUri).to.not.be.undefined;
+
+			await vscode.commands.executeCommand(START_DIDACT_COMMAND, didactFileUri);
+			try {
+				const predicate = () => didactManager.active() != undefined;
+				await waitUntil(predicate, { timeout: EDITOR_OPENED_TIMEOUT, intervalBetweenAttempts: 1000 }).then(() => {
+					expect(didactManager.active()?.getCurrentTitle()).to.equal("Local Didact Tutorial");
+				});
+			} catch (error) {
+				assert.fail(error);
+			}
+		} catch (error) {
+			assert.fail(error);
+		}
+	});
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -156,12 +156,12 @@ export async function registerTutorialWithClass(newDidact: Tutorial): Promise<vo
 		}
 		if (!match) {
 			existingRegistry.push(newDidactAsString);
-			await extensionFunctions.getContext().workspaceState.update(DIDACT_REGISTERED_SETTING, existingRegistry);
-			refreshTreeview();
 		} else {
 			extensionFunctions.sendTextToOutputChannel(`Didact tutorial with name ${newDidact.name} and category ${newDidact.category} already exists`);
 		}
 	}
+	await extensionFunctions.getContext().workspaceState.update(DIDACT_REGISTERED_SETTING, existingRegistry);
+	refreshTreeview();
 }
 
 export async function registerTutorialWithArgs(name : string, sourceUri : string, category : string ): Promise<void> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -401,8 +401,10 @@ async function quickPickCategory(
 					quickPick.value = '';
 					quickPick.items = options;
 				} else {
-					// include currently typed option
-					quickPick.items = [{ label: quickPick.value.trim() }, ...options];
+					// include currently typed option if it isn't already there
+					if (categories.indexOf(quickPick.value.trim()) === -1) {
+                        quickPick.items = [{ label: quickPick.value }, ...options];
+                    }
 				}
 			});
 		}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -338,6 +338,7 @@ async function getTutorialName(tutorialsForValidation : string[] ) : Promise<str
 	const result = await window.showInputBox({
 		value: 'New Tutorial',
 		placeHolder: 'Enter the name for your new tutorial. The name must be unique.',
+		ignoreFocusOut: true,
 		validateInput: (inputVal: string) => {
 			let val = validateTutorialNameInput(inputVal, tutorialsForValidation);
 			return val;
@@ -376,6 +377,7 @@ async function quickPickCategory(
 		quickPick.placeholder = placeholder;
 		quickPick.canSelectMany = canSelectMany;
 		quickPick.items = options;
+		quickPick.ignoreFocusOut = true;
 		let selectedItems: any[] = [];
 
 		if (canSelectMany) {
@@ -383,7 +385,6 @@ async function quickPickCategory(
 				selectedItems = selected;
 			});
 		}
-
 		quickPick.onDidAccept(_ => {
 			if (quickPick.value.trim().length > 0 || selectedItems.length > 0 || quickPick.activeItems.length > 0) {
 				if (canSelectMany) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -403,7 +403,7 @@ async function quickPickCategory(
 				} else {
 					// include currently typed option if it isn't already there
 					if (categories.indexOf(quickPick.value.trim()) === -1) {
-                        quickPick.items = [{ label: quickPick.value }, ...options];
+                        quickPick.items = [{ label: quickPick.value.trim() }, ...options];
                     }
 				}
 			});
@@ -412,14 +412,6 @@ async function quickPickCategory(
 		quickPick.onDidHide(_ => quickPick.dispose());
 		quickPick.show();
 	});
-}
-
-// get a single input
-async function getUserInput(prompt:string): Promise<string | undefined> {
-	return window.showInputBox({
-		prompt: `Enter a ${prompt}`,
-		placeHolder: prompt
-	});		
 }
 
 export async function removeTutorialByNameAndCategory(node : TutorialNode ) : Promise<boolean>{

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -355,13 +355,13 @@ async function getTutorialName(tutorialsForValidation : string[] ) : Promise<str
 
 function validateTutorialNameInput(value: string, tutorialsForValidation : string[] ): string | null {
 	if (typeof value === "string") {
-	  if (value.trim().length === 0) {
-		return "Empty tutorial name is not allowed";
-	  }
-	  if (tutorialsForValidation && tutorialsForValidation.indexOf(value) > -1) {
-		  return "Tutorial with that name already exists. Tutorial names must be unique."
-	  }
-	  return null;
+		if (value.trim().length === 0) {
+			return "Empty tutorial name is not allowed";
+		}
+		if (tutorialsForValidation && tutorialsForValidation.indexOf(value) > -1) {
+			return "Tutorial with that name already exists. Tutorial names must be unique."
+		}
+		return null;
 	}
   	return `${value} is invalid`;
 }
@@ -410,8 +410,8 @@ async function quickPickCategory(
 				} else {
 					// include currently typed option if it isn't already there
 					if (categories.indexOf(quickPick.value.trim()) === -1) {
-                        quickPick.items = [{ label: quickPick.value.trim() }, ...options];
-                    }
+						quickPick.items = [{ label: quickPick.value.trim() }, ...options];
+					}
 				}
 			});
 		}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -323,6 +323,9 @@ export async function addNewTutorialWithNameAndCategoryForDidactUri(uri: Uri, na
 
 		tutorialName = await getTutorialName(tutorialsForValidation);
 		const selectedCategory : string[] = await quickPickCategory(categoriesForValidation);
+		if (selectedCategory === undefined) {
+			throw Error("Canceled out of Tutorial Category selection");
+		}		
 		tutorialCategory = selectedCategory[0];
 	}
 	
@@ -344,6 +347,9 @@ async function getTutorialName(tutorialsForValidation : string[] ) : Promise<str
 			return val;
 		}
 	});
+	if (result === undefined) {
+		throw Error("Canceled out of Tutorial Name input box");
+	}
 	return result?.trim();
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -330,7 +330,7 @@ export async function addNewTutorialWithNameAndCategoryForDidactUri(uri: Uri, na
 		uri = await getCurrentFileSelectionPath();
 	}
 	if (tutorialName && tutorialCategory) {
-		await registerTutorialWithArgs(tutorialName, uri.fsPath, tutorialCategory);
+		await registerTutorialWithArgs(tutorialName, uri.toString(), tutorialCategory);
 	}
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -156,12 +156,12 @@ export async function registerTutorialWithClass(newDidact: Tutorial): Promise<vo
 		}
 		if (!match) {
 			existingRegistry.push(newDidactAsString);
+			await extensionFunctions.getContext().workspaceState.update(DIDACT_REGISTERED_SETTING, existingRegistry);
+			refreshTreeview();
 		} else {
-			throw new Error(`Didact tutorial with name ${newDidact.name} and category ${newDidact.category} already exists`);
+			extensionFunctions.sendTextToOutputChannel(`Didact tutorial with name ${newDidact.name} and category ${newDidact.category} already exists`);
 		}
 	}
-	await extensionFunctions.getContext().workspaceState.update(DIDACT_REGISTERED_SETTING, existingRegistry);
-	refreshTreeview();
 }
 
 export async function registerTutorialWithArgs(name : string, sourceUri : string, category : string ): Promise<void> {
@@ -289,9 +289,14 @@ export async function updateRegisteredTutorials(inJson : any): Promise<void>{
 	}
 }
 
-export async function addNewTutorialWithNameAndCategoryForDidactUri(uri: Uri) : Promise<void> {
-	const prompts : string[] = [ "Tutorial Name", "Tutorial Category" ];
-	const values : string[] = await collectUserInput(prompts);
+export async function addNewTutorialWithNameAndCategoryForDidactUri(uri: Uri, name? : string, category? : string) : Promise<void> {
+	let values : string[];
+	if (name && category) {
+		values = [ name, category ];
+	} else {
+		const prompts : string[] = [ "Tutorial Name", "Tutorial Category" ];
+		values = await collectUserInput(prompts);
+	}
 	if (!uri) {
 		uri = await getCurrentFileSelectionPath();
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -343,12 +343,12 @@ async function getTutorialName(tutorialsForValidation : string[] ) : Promise<str
 			return val;
 		}
 	});
-	return result;
+	return result?.trim();
 }
 
 function validateTutorialNameInput(value: string, tutorialsForValidation : string[] ): string | null {
 	if (typeof value === "string") {
-	  if (value === "") {
+	  if (value.trim().length === 0) {
 		return "Empty tutorial name is not allowed";
 	  }
 	  if (tutorialsForValidation && tutorialsForValidation.indexOf(value) > -1) {
@@ -370,7 +370,7 @@ async function quickPickCategory(
 		let placeholder = "Select a Tutorial Category.";
 
 		if (acceptInput) {
-			placeholder = "Select an existing Category or type a new, unique Category name.";
+			placeholder = "Select existing Category or type a new name. 'Enter' to confirm. 'Escape' to cancel.";
 		}
 
 		quickPick.placeholder = placeholder;
@@ -385,12 +385,14 @@ async function quickPickCategory(
 		}
 
 		quickPick.onDidAccept(_ => {
-			if (canSelectMany) {
-				resolve(selectedItems.map((item) => item.label));
-			} else {
-				resolve(quickPick.activeItems.map((item) => item.label));
+			if (quickPick.value.trim().length > 0 || selectedItems.length > 0 || quickPick.activeItems.length > 0) {
+				if (canSelectMany) {
+					resolve(selectedItems.map((item) => item.label));
+				} else {
+					resolve(quickPick.activeItems.map((item) => item.label));
+				}
+				quickPick.hide();
 			}
-			quickPick.hide();
 		});
 
 		if (acceptInput) {
@@ -400,7 +402,7 @@ async function quickPickCategory(
 					quickPick.items = options;
 				} else {
 					// include currently typed option
-					quickPick.items = [{ label: quickPick.value }, ...options];
+					quickPick.items = [{ label: quickPick.value.trim() }, ...options];
 				}
 			});
 		}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -360,53 +360,54 @@ function validateTutorialNameInput(value: string, tutorialsForValidation : strin
 }
 
 async function quickPickCategory(
-    categories: string[],
-    canSelectMany: boolean = false,
-    acceptInput: boolean = true): Promise<string[]> {
-    let options = categories.map(tag => ({ label: tag }));
+	categories: string[],
+	canSelectMany: boolean = false,
+	acceptInput: boolean = true): Promise<string[]> {
+	let options = categories.map(tag => ({ label: tag }));
 
-    return new Promise((resolve, _) => {
-        let quickPick = window.createQuickPick();
-        let placeholder = "Select a Tutorial Category.";
+	return new Promise((resolve, _) => {
+		let quickPick = window.createQuickPick();
+		let placeholder = "Select a Tutorial Category.";
 
-        if (acceptInput) {
-            placeholder = "Select an existing Category or type a new, unique Category name.";
-        }
+		if (acceptInput) {
+			placeholder = "Select an existing Category or type a new, unique Category name.";
+		}
 
-        quickPick.placeholder = placeholder;
-        quickPick.canSelectMany = canSelectMany;
-        quickPick.items = options;
-        let selectedItems: any[] = [];
+		quickPick.placeholder = placeholder;
+		quickPick.canSelectMany = canSelectMany;
+		quickPick.items = options;
+		let selectedItems: any[] = [];
 
-        if (canSelectMany) {
-            quickPick.onDidChangeSelection((selected) => {
-                selectedItems = selected;
-            });
-        }
+		if (canSelectMany) {
+			quickPick.onDidChangeSelection((selected) => {
+				selectedItems = selected;
+			});
+		}
 
-        quickPick.onDidAccept(_ => {
-            if (canSelectMany) {
-                resolve(selectedItems.map((item) => item.label));
-            } else {
-                resolve(quickPick.activeItems.map((item) => item.label));
-            }
-            quickPick.hide();
-        });
+		quickPick.onDidAccept(_ => {
+			if (canSelectMany) {
+				resolve(selectedItems.map((item) => item.label));
+			} else {
+				resolve(quickPick.activeItems.map((item) => item.label));
+			}
+			quickPick.hide();
+		});
 
-        if (acceptInput) {
-            quickPick.onDidChangeValue(_ => {
-                if (quickPick.value === "") {
-                    quickPick.items = options;
-                } else {
-                    // include currently typed option
-                    quickPick.items = [{ label: quickPick.value }, ...options];
-                }
-            });
-        }
+		if (acceptInput) {
+			quickPick.onDidChangeValue(_ => {
+				if (quickPick.value.trim().length === 0) {
+					quickPick.value = '';
+					quickPick.items = options;
+				} else {
+					// include currently typed option
+					quickPick.items = [{ label: quickPick.value }, ...options];
+				}
+			});
+		}
 
-        quickPick.onDidHide(_ => quickPick.dispose());
-        quickPick.show();
-    });
+		quickPick.onDidHide(_ => quickPick.dispose());
+		quickPick.show();
+	});
 }
 
 // get a single input

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -358,7 +358,10 @@ function validateTutorialNameInput(value: string, tutorialsForValidation : strin
 		if (value.trim().length === 0) {
 			return "Empty tutorial name is not allowed";
 		}
-		if (tutorialsForValidation && tutorialsForValidation.indexOf(value) > -1) {
+		if (value.endsWith(' ')) {
+			return "Spaces at end of tutorial name are not allowed";
+		}
+		if (tutorialsForValidation && tutorialsForValidation.indexOf(value.trim()) > -1) {
 			return "Tutorial with that name already exists. Tutorial names must be unique."
 		}
 		return null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -358,6 +358,9 @@ function validateTutorialNameInput(value: string, tutorialsForValidation : strin
 		if (value.trim().length === 0) {
 			return "Empty tutorial name is not allowed";
 		}
+		if (value.startsWith(' ')) {
+			return "Spaces at start of tutorial name are not allowed";
+		}
 		if (value.endsWith(' ')) {
 			return "Spaces at end of tutorial name are not allowed";
 		}


### PR DESCRIPTION
This will be a multiple commit project and this is the first chunk of work.

First commit adds:

* New setting to Automatically add the default Didact tutorials at startup if they are not present
* New command vscode.didact.registry.clear (not shown in the Didact Tutorials view, but present in the Command Palette)
* New command vscode.didact.registry.addJson used to add a new tutorial to the registry (JSON looks like ```{
			"name" : `tutorial name`,
			"category" : `exact category name`,
			"sourceUri" : `file/http URI to file`,
		};```)
* New tests validate these additional functions and verify that the older registerTutorialWithCategory method still works (though it now hands off to a registerTutorialWithArgs method)
* Added a class to handle the name/category/uri details for a new tutorial to more explicitly codify the format
* Removes the calls to clear the registry on startup and shutdown, relying on what's stored in the workspace settings

Second round of changes:
* New right-click menu `Didact: Register Didact Tutorial` on Didact files in the Explorer view enables user-registered tutorials to appear in `Didact Tutorials` view
* New right-click menu `Remove Didact Tutorial` on tutorials in `Didact Tutorials` view enables tutorial removal

Third round:
* Added an example of how to register a new tutorial via a Didact link along with all the other new bits

Fourth round:
* Updated the user prompts when registering a new tutorial. We now validate the name and provide an editable dropdown list of existing categories.

Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>