### PR TITLE
adding che badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 <a href="https://circleci.com/gh/redhat-developer/vscode-didact"><img src="https://circleci.com/gh/redhat-developer/vscode-didact.svg?style=shield"></a>
 <img src="https://img.shields.io/badge/license-Apache%202-blue.svg" alt="License"/>
 <a href="https://gitter.im/redhat-developer/vscode-didact"><img src="https://img.shields.io/gitter/room/redhat-developer/home.js.sv" alt="Gitter"/></a>
+<a href="https://workspaces.openshift.com/f?url=https://github.com/redhat-developer/vscode-didact"><img src="https://www.eclipse.org/che/contribute.svg" alt="Contribute"/></a>
+
 </p><br/>
 
 <p align="center"><img src="./images/open-new-terminal-example.gif" alt="Three Step Didact Tutorial Example" width="100%"/></p><br/>


### PR DESCRIPTION
Adding a Che badge as suggested by https://www.eclipse.org/che/docs/che-7/end-user-guide/workspaces-overview/#_including_the_developer_workspace_badge_in_a_readme

![image](https://user-images.githubusercontent.com/530878/112843440-cec14e80-905f-11eb-9f03-1174beecb9d3.png)

It does eventually come up from the link https://workspaces.openshift.com/f?url=https://github.com/redhat-developer/vscode-didact

![image](https://user-images.githubusercontent.com/530878/112843521-e698d280-905f-11eb-9591-45ffaa2e46d6.png)

So that's kind of nice! Definitely takes a bit to get there but it's great to have an in-house approach to doing the same thing as something like https://www.gitpod.io/


Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>