### PR TITLE
FUSETOOLS2-1064 - add confirmation to clear

### DIFF
--- a/src/test/suite/registry.test.ts
+++ b/src/test/suite/registry.test.ts
@@ -15,7 +15,7 @@ const source2 = 'my-uri-2';
 suite('Didact registry test suite', () => {
 
 	before('set up the registry tests', async () => {
-		await clearRegisteredTutorials();
+		await clearRegisteredTutorials(false);
 	});
 
 	test('assert that clearing the registry made it empty', async () => {
@@ -119,7 +119,7 @@ suite('Didact registry test suite', () => {
 		const registry = getRegisteredTutorials();
 		assert.notStrictEqual(registry, undefined);
 
-		await clearRegisteredTutorials();
+		await clearRegisteredTutorials(false);
 
 		const afterregistry = getRegisteredTutorials();
 		assert.deepStrictEqual(afterregistry, undefined);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -246,7 +246,14 @@ export function getUriForDidactNameAndCategory(name : string, category : string 
 	return undefined;
 }
 
-export async function clearRegisteredTutorials(): Promise<void>{
+export async function clearRegisteredTutorials(prompt = true): Promise<void>{
+	if (prompt) {
+		const confirmDelete = `Are you sure you want to clear all registered Didact tutorials? This cannot be undone.`;
+		const result = await window.showWarningMessage(confirmDelete, 'Yes', 'No');
+		if (result === 'No') {
+			return;
+		}
+	}
 	if (workspace.getConfiguration()) {
 		await extensionFunctions.getContext().workspaceState.update(DIDACT_REGISTERED_SETTING, undefined);
 		console.log('Didact configuration cleared');


### PR DESCRIPTION
Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>

While going through documenting the process of adding new tutorials to the registry, it became very apparent we needed to add a final "are you sure?" check when they use the command to clear the registry.

![didact-clear-registry-confirmation](https://user-images.githubusercontent.com/530878/114454957-695d7980-9b98-11eb-96d9-a5bc1e3c8afe.gif)
