### PR TITLE
FUSETOOLS2-1051 - fixing flaky tests in stub and completion

### DIFF
--- a/src/test/suite/completions.test.ts
+++ b/src/test/suite/completions.test.ts
@@ -63,7 +63,7 @@ suite("New Didact URI completion provider tests", function () {
 async function testWeGetExpectedResult(textToInsert : string, expectedResult: string) {
 	const editor = await createTestEditor(testDocumentUri);
 	const _disposables: vscode.Disposable[] = [];
-	const DELAY_TIME = 500;
+	const DELAY_TIME = 150;
 	await delay(DELAY_TIME);
 	await initializeTextEditor(editor, textToInsert);
 	await delay(DELAY_TIME);
@@ -99,6 +99,7 @@ async function createTestEditor(uri: vscode.Uri) : Promise<vscode.TextEditor> {
 	return activeEditor;
 }
 
+// https://github.com/microsoft/vscode/blob/94c9ea46838a9a619aeafb7e8afd1170c967bb55/extensions/typescript-language-features/src/test/suggestTestHelpers.ts#L10
 async function acceptFirstSuggestion(uri: vscode.Uri, _disposables: vscode.Disposable[]) {
 	return retryUntilDocumentChanges(uri, { retries: 10, timeout: 0 }, _disposables, async () => {
 		await vscode.commands.executeCommand('editor.action.triggerSuggest');
@@ -107,6 +108,7 @@ async function acceptFirstSuggestion(uri: vscode.Uri, _disposables: vscode.Dispo
 	});
 }
 
+// https://github.com/microsoft/vscode/blob/94c9ea46838a9a619aeafb7e8afd1170c967bb55/extensions/typescript-language-features/src/test/testUtils.ts#L141
 export function onChangedDocument(documentUri: vscode.Uri, disposables: vscode.Disposable[]) {
 	return new Promise<vscode.TextDocument>(resolve => vscode.workspace.onDidChangeTextDocument(e => {
 		if (e.document.uri.toString() === documentUri.toString()) {
@@ -115,16 +117,14 @@ export function onChangedDocument(documentUri: vscode.Uri, disposables: vscode.D
 	}, undefined, disposables));
 }
 
+// https://github.com/microsoft/vscode/blob/94c9ea46838a9a619aeafb7e8afd1170c967bb55/extensions/typescript-language-features/src/test/testUtils.ts#L149
 export async function retryUntilDocumentChanges(
 	documentUri: vscode.Uri,
 	options: { retries: number, timeout: number },
 	disposables: vscode.Disposable[],
-	exec: () => Thenable<unknown>,
-) {
+	exec: () => Thenable<unknown>, ) {
 	const didChangeDocument = onChangedDocument(documentUri, disposables);
-
 	let done = false;
-
 	const result = await Promise.race([
 		didChangeDocument,
 		(async () => {

--- a/src/test/suite/completions.test.ts
+++ b/src/test/suite/completions.test.ts
@@ -62,16 +62,14 @@ suite("New Didact URI completion provider tests", function () {
 
 async function testWeGetExpectedResult(textToInsert : string, expectedResult: string) {
 	const editor = await createTestEditor(testDocumentUri);
-	const DELAY_TIME = 150;
+	const _disposables: vscode.Disposable[] = [];
+	const DELAY_TIME = 500;
 	await delay(DELAY_TIME);
 	await initializeTextEditor(editor, textToInsert);
 	await delay(DELAY_TIME);
 	await vscode.commands.executeCommand("cursorEnd");
 	await delay(DELAY_TIME);
-	await vscode.commands.executeCommand("editor.action.triggerSuggest");
-	await delay(DELAY_TIME);
-	await vscode.commands.executeCommand("acceptSelectedSuggestion");
-	await delay(DELAY_TIME);
+	await acceptFirstSuggestion(testDocumentUri, _disposables);
 	expect(editor.document.getText()).to.include(expectedResult);
 }
 
@@ -99,4 +97,46 @@ async function createTestEditor(uri: vscode.Uri) : Promise<vscode.TextEditor> {
 		throw new Error('no active editor');
 	}
 	return activeEditor;
+}
+
+async function acceptFirstSuggestion(uri: vscode.Uri, _disposables: vscode.Disposable[]) {
+	return retryUntilDocumentChanges(uri, { retries: 10, timeout: 0 }, _disposables, async () => {
+		await vscode.commands.executeCommand('editor.action.triggerSuggest');
+		await delay(1000);
+		await vscode.commands.executeCommand('acceptSelectedSuggestion');
+	});
+}
+
+export function onChangedDocument(documentUri: vscode.Uri, disposables: vscode.Disposable[]) {
+	return new Promise<vscode.TextDocument>(resolve => vscode.workspace.onDidChangeTextDocument(e => {
+		if (e.document.uri.toString() === documentUri.toString()) {
+			resolve(e.document);
+		}
+	}, undefined, disposables));
+}
+
+export async function retryUntilDocumentChanges(
+	documentUri: vscode.Uri,
+	options: { retries: number, timeout: number },
+	disposables: vscode.Disposable[],
+	exec: () => Thenable<unknown>,
+) {
+	const didChangeDocument = onChangedDocument(documentUri, disposables);
+
+	let done = false;
+
+	const result = await Promise.race([
+		didChangeDocument,
+		(async () => {
+			for (let i = 0; i < options.retries; ++i) {
+				await delay(options.timeout);
+				if (done) {
+					return;
+				}
+				await exec();
+			}
+		})(),
+	]);
+	done = true;
+	return result;
 }

--- a/src/test/suite/stubDemoTutorial.test.ts
+++ b/src/test/suite/stubDemoTutorial.test.ts
@@ -40,105 +40,100 @@ suite('stub out a tutorial', () => {
 	});
 
 	test('that we can get a response from each command in the demo tutorial', async () => {
-		await commands.executeCommand(START_DIDACT_COMMAND, testMD).then( async () => {
-			if (didactManager.active()) {
-
-				suite('walk through all the sendNamedTerminalAString commands in the demo', () => {
-					const commandsToTest : any[] = gatherAllCommandsLinks().filter( (href) => href.match(/=vscode.didact.sendNamedTerminalAString&/g));
-					expect(commandsToTest).to.not.be.empty;
-					commandsToTest.forEach(function(href: string) {
-						test(`test terminal command "${href}"`, async () => {
-							const ctxt = getContext();
-							if (ctxt) {
-								const testUri = new DidactUri(href, ctxt);
-								const textToParse = testUri.getText();
-								const userToParse = testUri.getUser();
-								let outputs : string[] = [];
-								if (textToParse) {
-									handleText(textToParse, outputs);
-								} else if (userToParse) {
-									handleText(userToParse, outputs);
-								}
-								expect(outputs).length.to.be.at.least(2);
-								const terminalName = outputs[0];
-								const terminalString = outputs[1];
-								await validateTerminalResponse(terminalName, terminalString);
-							}
-						});
-					});
-				});				
-			}
-		});
+		await commands.executeCommand(START_DIDACT_COMMAND, testMD);
+		if (didactManager.active()) {
+			const commandsToTest: any[] = gatherAllCommandsLinks().filter( (href) => href.match(/=vscode.didact.sendNamedTerminalAString&/g));
+			expect(commandsToTest).to.not.be.empty;
+			commandsToTest.forEach(async (href: string) => {
+				const ctxt = getContext();
+				if (ctxt) {
+					const testUri = new DidactUri(href, ctxt);
+					const textToParse = testUri.getText();
+					const userToParse = testUri.getUser();
+					let outputs : string[] = [];
+					if (textToParse) {
+						handleText(textToParse, outputs);
+					} else if (userToParse) {
+						handleText(userToParse, outputs);
+					}
+					expect(outputs).length.to.be.at.least(2);
+					const terminalName = outputs[0];
+					const terminalString = outputs[1];
+					await validateTerminalResponse(terminalName, terminalString);
+				}
+			});
+		}
 	});
 
-});
 
-async function validateTerminalResponse(terminalName : string, terminalText : string, terminalResponse? : string) {
-	console.log(`validateTerminalResponse terminal ${terminalName} executing text ${terminalText}`);
-	const term = window.createTerminal(terminalName);
-	expect(term).to.not.be.null;
-	if (term) {
-		console.log(`-current terminal = ${term?.name}`);
-		await sendTerminalText(terminalName, terminalText);
+	async function validateTerminalResponse(terminalName : string, terminalText : string, terminalResponse? : string) {
+		console.log(`validateTerminalResponse terminal ${terminalName} executing text ${terminalText}`);
+		const term = window.createTerminal(terminalName);
+		expect(term).to.not.be.null;
+		if (term) {
+			console.log(`-current terminal = ${term?.name}`);
+			await sendTerminalText(terminalName, terminalText);
 
-		await waitUntil(async () => {
-			focusOnNamedTerminal(terminalName);
-			return terminalName === window.activeTerminal?.name;
-		}, 1000);
+			await waitUntil(async () => {
+				focusOnNamedTerminal(terminalName);
+				return terminalName === window.activeTerminal?.name;
+			}, 1000);
 
-		try {
-			const predicate = async () => {
-				const result = await getActiveTerminalOutput();
-				return result.includes(getExpectedTextInTerminal());
-			};
-			await waitUntil(predicate, { timeout: COMMAND_WAIT_TIMEOUT, intervalBetweenAttempts: COMMAND_WAIT_RETRY });
-		} catch (error){
-			console.log(`Searching for ${getExpectedTextInTerminal()} but not found in current content of active terminal ${window.activeTerminal?.name} : ${await getActiveTerminalOutput()}`);
-			fail(error);
+			try {
+				const predicate = async () => {
+					const result = await getActiveTerminalOutput();
+					return result.includes(getExpectedTextInTerminal());
+				};
+				await waitUntil(predicate, { timeout: COMMAND_WAIT_TIMEOUT, intervalBetweenAttempts: COMMAND_WAIT_RETRY });
+			} catch (error){
+				console.log(`Searching for ${getExpectedTextInTerminal()} but not found in current content of active terminal ${window.activeTerminal?.name} : ${await getActiveTerminalOutput()}`);
+				fail(error);
+			}
+			findAndDisposeTerminal(terminalName);
 		}
-		findAndDisposeTerminal(terminalName);
+
+		function getExpectedTextInTerminal() {
+			return terminalResponse ? terminalResponse : terminalText;
+		}
 	}
 
-	function getExpectedTextInTerminal() {
-		return terminalResponse ? terminalResponse : terminalText;
+	async function getActiveTerminalOutput() : Promise<string> {
+		const term = window.activeTerminal;
+		console.log(`-current terminal = ${term?.name}`);
+		await executeAndWait('workbench.action.terminal.selectAll');
+		await delay(delayTime);
+		await executeAndWait('workbench.action.terminal.copySelection');
+		await executeAndWait('workbench.action.terminal.clearSelection');	
+		const clipboard_content = await env.clipboard.readText();
+		return clipboard_content.trim();
 	}
-}
 
-async function getActiveTerminalOutput() : Promise<string> {
-	const term = window.activeTerminal;
-	console.log(`-current terminal = ${term?.name}`);
-	await executeAndWait('workbench.action.terminal.selectAll');
-	await delay(delayTime);
-	await executeAndWait('workbench.action.terminal.copySelection');
-	await executeAndWait('workbench.action.terminal.clearSelection');	
-	const clipboard_content = await env.clipboard.readText();
-	return clipboard_content.trim();
-}
-
-function delay(ms: number) {
-	return new Promise( resolve => setTimeout(resolve, ms) );
-}
-
-async function executeAndWait(command: string): Promise<void> {
-	await commands.executeCommand(command);
-	delay(100);
-}
-
-function getNamedTerminal(terminalName : string): Terminal | undefined {
-	return window.terminals.filter(term => term.name === terminalName)[0];
-}
-
-function findAndDisposeTerminal(terminalName: string) : void {
-	const term = getNamedTerminal(terminalName);
-	if (term) {
-		term.dispose();
+	function delay(ms: number) {
+		return new Promise( resolve => setTimeout(resolve, ms) );
 	}
-}
 
-async function focusOnNamedTerminal(terminalName : string) : Promise<void> {
-	let term = window.activeTerminal;
-	while (term?.name != terminalName) {
-		await commands.executeCommand('workbench.action.terminal.focusNext');
-		term = window.activeTerminal;
+	async function executeAndWait(command: string): Promise<void> {
+		await commands.executeCommand(command);
+		delay(100);
 	}
-}
+
+	function getNamedTerminal(terminalName : string): Terminal | undefined {
+		return window.terminals.filter(term => term.name === terminalName)[0];
+	}
+
+	function findAndDisposeTerminal(terminalName: string) : void {
+		const term = getNamedTerminal(terminalName);
+		if (term) {
+			term.dispose();
+		}
+	}
+
+	async function focusOnNamedTerminal(terminalName : string) : Promise<void> {
+		let term = window.activeTerminal;
+		while (term?.name != terminalName) {
+			await commands.executeCommand('workbench.action.terminal.focusNext');
+			term = window.activeTerminal;
+		}
+	}
+
+});


### PR DESCRIPTION
Testing the work that @lhein did with https://github.com/redhat-developer/vscode-didact/pull/501 in a rebased branch with latest changes to fix the stub tests for terminal 

But also found a fix for the completion test that was hanging us up, borrowing a couple of methods from a Microsoft test harness (links included in code comments)

Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>