### PR TITLE
FUSETOOLS2-1063 - extend uri handler

### DIFF
--- a/examples/vscode-links.didact.md
+++ b/examples/vscode-links.didact.md
@@ -1,0 +1,19 @@
+# Using VSCode links
+
+Using `vscode` protocol links (https://code.visualstudio.com/api/references/vscode-api#window.registerUriHandler)
+
+## Linking to other Didact files
+
+[You can open remote Didact tutorials remotely - this one is on GitHub](vscode://redhat.vscode-didact?https=raw.githubusercontent.com/redhat-developer/vscode-didact/master/examples/requirements.example.didact.md)
+
+## Registering from a Distance
+
+[You can register remote Didact tutorials in the Didact Tutorials view by providing a url, name, and category](vscode://redhat.vscode-didact?commandId=vscode.didact.registry.addUri&&https=raw.githubusercontent.com/redhat-developer/vscode-didact/master/examples/requirements.example.didact.md&&name=Requirements%20Example&&category=From%20The%20Web)
+
+## Using the File URL
+
+[Using the vscode/file url approach requires the full path to the project.](https://code.visualstudio.com/docs/editor/command-line#_opening-vs-code-with-urls)
+
+## Using the Extension URL
+
+Using the `vscode:extension/[extId]` link can open the extension page inside VS Code. For example, to open the `Apache Camel Extension Pack`, you can use [this link](vscode:extension/redhat.apache-camel-extension-pack)

--- a/package.json
+++ b/package.json
@@ -139,6 +139,10 @@
 					"dark": "resources/dark/run.svg",
 					"light": "resources/light/run.svg"
 				}
+			},
+			{
+				"command": "vscode.didact.processVSCodeLink",
+				"title": "Didact: Process VSCode link from web"
 			}
 		],
 		"keybindings": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ import { registerTutorialWithCategory, clearRegisteredTutorials, getOpenAtStartu
 import { DidactUriCompletionItemProvider } from './didactUriCompletionItemProvider';
 import { DidactPanelSerializer } from './didactPanelSerializer';
 import { didactManager, VIEW_TYPE } from './didactManager';
-import { handleVSCodeDidactUriParsingForPath } from './extensionFunctions';
+import { handleVSCodeDidactUriParsingForPath, sendTextToOutputChannel } from './extensionFunctions';
 import * as querystring from 'querystring';
 
 const DIDACT_VIEW = 'didact.tutorials';
@@ -85,6 +85,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 					const tutname : string | undefined = getValue(query.name);
 					const tutcat : string | undefined = getValue(query.category);
 					await addNewTutorialWithNameAndCategoryForDidactUri(out, tutname, tutcat);
+				} else {
+					sendTextToOutputChannel(`No parseable Didact file uri discovered in URI sent via vscode link ${uri.toString()}`);
 				}
 			} else {
 				await vscode.commands.executeCommand(extensionFunctions.START_DIDACT_COMMAND, uri);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ import { registerTutorialWithCategory, clearRegisteredTutorials, getOpenAtStartu
 import { DidactUriCompletionItemProvider } from './didactUriCompletionItemProvider';
 import { DidactPanelSerializer } from './didactPanelSerializer';
 import { didactManager, VIEW_TYPE } from './didactManager';
-import { handleVSCodeDidactUriParsingForPath, sendTextToOutputChannel } from './extensionFunctions';
+import { handleVSCodeDidactUriParsingForPath, handleVSCodeUri, sendTextToOutputChannel } from './extensionFunctions';
 import * as querystring from 'querystring';
 
 const DIDACT_VIEW = 'didact.tutorials';
@@ -74,23 +74,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.ADD_TUTORIAL_URI_TO_REGISTRY, addNewTutorialWithNameAndCategoryForDidactUri));
 	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.REMOVE_TUTORIAL_BY_NAME_AND_CATEGORY_FROM_REGISTRY, removeTutorialByNameAndCategory));
 	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.OPEN_TUTORIAL_HEADING_FROM_VIEW, didactManager.openHeading));
+	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.PROCESS_VSCODE_LINK, handleVSCodeUri));	
 
 	// set up the vscode URI handler
 	vscode.window.registerUriHandler({
 		async handleUri(uri:vscode.Uri) {
-			const query = querystring.parse(uri.query);
-			if (query.commandId && query.commandId === extensionFunctions.ADD_TUTORIAL_URI_TO_REGISTRY && query.https && query.name && query.category) {
-				const out : vscode.Uri | undefined = handleVSCodeDidactUriParsingForPath(uri);
-				if (out) {
-					const tutname : string | undefined = getValue(query.name);
-					const tutcat : string | undefined = getValue(query.category);
-					await addNewTutorialWithNameAndCategoryForDidactUri(out, tutname, tutcat);
-				} else {
-					sendTextToOutputChannel(`No parseable Didact file uri discovered in URI sent via vscode link ${uri.toString()}`);
-				}
-			} else {
-				await vscode.commands.executeCommand(extensionFunctions.START_DIDACT_COMMAND, uri);
-			}
+			await handleVSCodeUri(uri);
 		}
 	});
 

--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -329,6 +329,9 @@ export function handleVSCodeDidactUriParsingForPath(uri:vscode.Uri) : vscode.Uri
 }
 
 export async function revealOrStartDidactByURI(uri : vscode.Uri, viewColumn? : string) : Promise <void> {
+	if (!uri) {
+		uri = await getCurrentFileSelectionPath();
+	}
 	if (uri) {
 		const parentPanel = didactManager.getByUri(uri);
 		if (parentPanel) {

--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -28,7 +28,7 @@ import { handleExtFilePath, handleProjectFilePath } from './commandHandler';
 import * as download from 'download';
 import { didactManager } from './didactManager';
 import { parse } from 'node-html-parser';
-import { delay, DIDACT_DEFAULT_URL, getCachedOutputChannel, getCurrentFileSelectionPath, getValue, getWorkspacePath, registerTutorialWithCategory, rememberOutputChannel } from './utils';
+import { addNewTutorialWithNameAndCategoryForDidactUri, delay, DIDACT_DEFAULT_URL, getCachedOutputChannel, getCurrentFileSelectionPath, getValue, getWorkspacePath, registerTutorialWithCategory, rememberOutputChannel } from './utils';
 
 const tmp = require('tmp');
 const fetch = require('node-fetch');
@@ -71,6 +71,7 @@ export const ADD_TUTORIAL_TO_REGISTRY = 'vscode.didact.registry.addJson';
 export const ADD_TUTORIAL_URI_TO_REGISTRY = 'vscode.didact.registry.addUri';
 export const REMOVE_TUTORIAL_BY_NAME_AND_CATEGORY_FROM_REGISTRY = 'vscode.didact.view.tutorial.remove';
 export const OPEN_TUTORIAL_HEADING_FROM_VIEW = "vscode.didact.view.tutorial.heading.open";
+export const PROCESS_VSCODE_LINK = "vscode.didact.processVSCodeLink";
 
 export const EXTENSION_ID = "redhat.vscode-didact";
 
@@ -1080,4 +1081,54 @@ export function getActualUri(uriString : string | undefined ) : vscode.Uri | und
 		actualUri = vscode.Uri.parse(uriString);
 	}
 	return actualUri;
+}
+
+function validateUriHasPath(textToValidate : string) : vscode.Uri | undefined {
+	try {
+		const uriToValidate = vscode.Uri.parse(textToValidate, true);
+		return handleVSCodeDidactUriParsingForPath(uriToValidate);
+	} catch (error) {
+		// just return
+	}
+	return undefined;
+}
+
+export async function handleVSCodeUri(uri:vscode.Uri | undefined) : Promise<void> {
+	let uriToProcess : vscode.Uri | undefined = uri;
+	if (!uriToProcess) {
+		// try clipboard
+		const textFromClipboard = await vscode.env.clipboard.readText();
+		const pathFromClipboard = validateUriHasPath(textFromClipboard);
+		if (textFromClipboard && pathFromClipboard) {
+			uriToProcess = vscode.Uri.parse(textFromClipboard);
+		}
+		if (!uriToProcess) {
+			await vscode.window.showInputBox({prompt: `Paste in the link from the web`}).then((textValueInput) => {
+				if (textValueInput && validateUriHasPath(textValueInput)) {
+					uriToProcess = vscode.Uri.parse(textValueInput);
+				} else {
+					const msg = `No parseable Didact file uri discovered in text provided '${textValueInput}'`;
+					sendTextToOutputChannel(msg);
+					vscode.window.showWarningMessage(msg);
+				}
+			});
+		}
+	}
+	if (uriToProcess) {
+		const query = querystring.parse(uriToProcess.query);
+		if (query.commandId && query.commandId === ADD_TUTORIAL_URI_TO_REGISTRY && query.https && query.name && query.category) {
+			const out : vscode.Uri | undefined = handleVSCodeDidactUriParsingForPath(uriToProcess);
+			if (out) {
+				const tutname : string | undefined = getValue(query.name);
+				const tutcat : string | undefined = getValue(query.category);
+				await addNewTutorialWithNameAndCategoryForDidactUri(out, tutname, tutcat);
+			} else {
+				const msg = `No parseable Didact file uri discovered in URI sent via vscode link '${uriToProcess.toString()}'`;
+				sendTextToOutputChannel(msg);
+				vscode.window.showWarningMessage(msg);
+			}
+		} else {
+			await vscode.commands.executeCommand(START_DIDACT_COMMAND, uriToProcess);
+		}
+	}
 }

--- a/src/test/suite/didact.test.ts
+++ b/src/test/suite/didact.test.ts
@@ -22,7 +22,7 @@ import * as fs from 'fs';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as extensionFunctions from '../../extensionFunctions';
-import {delay, getValue} from '../../utils';
+import {getValue} from '../../utils';
 import * as commandHandler from '../../commandHandler';
 import { removeFilesAndFolders } from '../../utils';
 
@@ -270,12 +270,12 @@ suite('Didact test suite', () => {
 	});
 
 	test('make sure we can open a didact file from a vscode extension', async () => {
+		const titleToCheck = 'Didact Terminal Commands';
 		await extensionFunctions.handleVSCodeUri(testMD5);
-		await delay(1000);
-		if (didactManager.active()) {
-			const title : string | undefined = didactManager.active()?.getCurrentTitle();
-			expect(title).to.equal('Didact Terminal Commands');
-		}
+		await waitUntil(() => didactManager.active()?.getCurrentTitle() ===  titleToCheck, 
+			{ timeout: EDITOR_OPENED_TIMEOUT, intervalBetweenAttempts: 1000 });
+		expect(didactManager.active()).to.not.be.undefined;
+		expect(didactManager.active()?.getCurrentTitle()).to.equal(titleToCheck);
 	});
 
 	test('make sure we can register a didact file from a vscode extension', async () => {

--- a/src/test/suite/didactUriCompletionItemProvider.test.ts
+++ b/src/test/suite/didactUriCompletionItemProvider.test.ts
@@ -110,7 +110,7 @@ suite("Didact URI completion provider tests", function () {
 	test("that the command processing for a command prefix returns expected results", async () => {
 		const match = provider.findMatchForCommandVariable('didact://?commandId=vscode.didact.');
 		const completionList = await provider.processCommands(match);
-		expect(completionList.items).to.have.lengthOf(32)
+		expect(completionList.items).to.have.lengthOf(33)
 	});
 
 	test("that the command processing for one command returns one expected result", async () => {


### PR DESCRIPTION
to register an https-based tutorial with name and category

added more `vscode://` link support and the beginning of calling different didact commands from a web link

Still exploring how to make a `vscode://` link not get ignored in a GitHub markdown file, but for now we can copy the text of the command from the web browser and use the `Didact: Process vscode link from web` to pick up the Uri from the clipboard or enable the user to paste it in. 

These links work fine inside a Didact window, but trying to make them work from outside is a bit more difficult. 

![Peek 2021-04-15 10-36](https://user-images.githubusercontent.com/530878/114929537-264a1300-9df1-11eb-986c-b968572a7723.gif)

The web page in the demo is hosted here: https://github.com/bfitzpat/didact-tutorials/blob/main/README.md. But the idea is to provide a repository where devs and tutorial authors can create easy links to add to their Didact Tutorials view 

Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>