### PR TITLE
FUSETOOLS2-1067 - add key shortcut to convert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to the "vscode-didact" extension will be documented in this 
 - Added confirmation to `Didact: Clear Tutorial Registry` to add extra check before clearing the tutorial registry
 - Added `Insert Didact Badge` completion to show `Powered by Didact` badge with link back to the project in GitHub
 - Added new `vscode` URI processing to handle registering a Didact tutorial via a web link and a new command - `Didact: Process VSCode link from web` to process a copied link
+- Add new `Ctrl/Cmd+Alt+T` shortcut to convert selected text into a `sendNamedTerminalAString` Didact link
 
 ## 0.3.2
 

--- a/package.json
+++ b/package.json
@@ -143,6 +143,10 @@
 			{
 				"command": "vscode.didact.processVSCodeLink",
 				"title": "Didact: Process VSCode link from web"
+			},
+			{
+				"command": "vscode.didact.copyTextToCLI",
+				"title": "Didact: Create Didact sendToTerminal link from selected text"
 			}
 		],
 		"keybindings": [
@@ -150,6 +154,12 @@
 				"command": "vscode.didact.startDidact",
 				"key": "ctrl+shift+v",
 				"mac": "cmd+shift+v",
+				"when": "editorFocus && resourceFilename =~ /[.](didact)[.](md|adoc)$/"
+			},
+			{
+				"command": "vscode.didact.copyTextToCLI",
+				"key": "ctrl+alt+t",
+				"mac": "cmd+alt+t",
 				"when": "editorFocus && resourceFilename =~ /[.](didact)[.](md|adoc)$/"
 			}
 		],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,7 +74,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.ADD_TUTORIAL_URI_TO_REGISTRY, addNewTutorialWithNameAndCategoryForDidactUri));
 	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.REMOVE_TUTORIAL_BY_NAME_AND_CATEGORY_FROM_REGISTRY, removeTutorialByNameAndCategory));
 	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.OPEN_TUTORIAL_HEADING_FROM_VIEW, didactManager.openHeading));
-	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.PROCESS_VSCODE_LINK, handleVSCodeUri));	
+	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.PROCESS_VSCODE_LINK, handleVSCodeUri));
+	context.subscriptions.push(vscode.commands.registerCommand(extensionFunctions.CREATE_SEND_TO_TERMINAL_LINK_FROM_SELECTED_TEXT, extensionFunctions.convertSelectionToCLILinkAndInsertAfterSelection));
 
 	// set up the vscode URI handler
 	vscode.window.registerUriHandler({

--- a/src/test/suite/didactUriCompletionItemProvider.test.ts
+++ b/src/test/suite/didactUriCompletionItemProvider.test.ts
@@ -110,7 +110,7 @@ suite("Didact URI completion provider tests", function () {
 	test("that the command processing for a command prefix returns expected results", async () => {
 		const match = provider.findMatchForCommandVariable('didact://?commandId=vscode.didact.');
 		const completionList = await provider.processCommands(match);
-		expect(completionList.items).to.have.lengthOf(33)
+		expect(completionList.items).to.have.lengthOf(34)
 	});
 
 	test("that the command processing for one command returns one expected result", async () => {


### PR DESCRIPTION
text to CLI (with URLencoding;  no validation that it's a valid command line string)

Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>

![Peek 2021-04-22 16-29](https://user-images.githubusercontent.com/530878/115794702-b1944d00-a38b-11eb-8ef5-b3cad6b52b0b.gif)
