### PR TITLE
FUSETOOLS2-1055 - fixing promise issues with tests

### DIFF
--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -477,7 +477,10 @@ function showFileUnavailable(error : any): void {
 	if (_didactFileUri) {
 		vscode.window.showErrorMessage(`File at ${_didactFileUri.toString()} is unavailable`);
 	}
-	console.log(error);
+	if (error instanceof Error) {
+		const err = error as Error;
+		console.log(err.message);
+	}
 }
 
 // retrieve the didact content to render as HTML

--- a/src/scaffoldUtils.ts
+++ b/src/scaffoldUtils.ts
@@ -17,6 +17,7 @@
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 import * as path from 'path';
+import { delay } from './utils';
 
 // prototypical sample project with a few folders and a file with text content provided
 export function createSampleProject(): JSON {
@@ -75,22 +76,20 @@ export async function createFoldersFromJSON(json: any, jsonpath: vscode.Uri): Pr
 			throw new Error('No workspace folder. Workspace must have at least one folder before Didact scaffolding can begin. Add a folder, restart your workspace, and then try again.');
 		}
 		let rootPath: string | undefined;
-		await vscode.commands.executeCommand('workbench.view.explorer').then ( async () => {
-			await vscode.commands.executeCommand('copyFilePath').then ( async () => {
-				await vscode.env.clipboard.readText().then((copyPath) => {
-					try {
-						if (fs.existsSync(copyPath)) {
-							if (fs.lstatSync(copyPath).isDirectory()) {
-								rootPath = copyPath;
-							} else {
-								rootPath = path.dirname(copyPath);
-							}
-						}
-					} catch (err) {
-						console.log(err);
+		await vscode.commands.executeCommand('workbench.view.explorer');
+		await vscode.commands.executeCommand('copyFilePath');
+		await vscode.env.clipboard.readText().then((copyPath) => {
+			try {
+				if (fs.existsSync(copyPath)) {
+					if (fs.lstatSync(copyPath).isDirectory()) {
+						rootPath = copyPath;
+					} else {
+						rootPath = path.dirname(copyPath);
 					}
-				});
-			});	
+				}
+			} catch (err) {
+				console.log(err);
+			}
 		});
 		if (!rootPath) {
 			if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0]) {


### PR DESCRIPTION
Ok @lhein I can use some help on this one. I have cleaned up some of the ugliness with reported stack traces in tests, but am stuck on these:
```
rejected promise not handled within 1 second: Error: Unknown webview handle:6e70bd07-dc69-4c0d-87a3-79f6e4bcb757
stack trace: Error: Unknown webview handle:6e70bd07-dc69-4c0d-87a3-79f6e4bcb757
    at js.getWebview (file:///Users/runner/work/vscode-didact/vscode-didact/.vscode-test/vscode-darwin-1.55.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:1582:76854)
    at js.$postMessage (file:///Users/runner/work/vscode-didact/vscode-didact/.vscode-test/vscode-darwin-1.55.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:1582:76090)
    at s._doInvokeHandler (file:///Users/runner/work/vscode-didact/vscode-didact/.vscode-test/vscode-darwin-1.55.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:1589:11903)
    at s._invokeHandler (file:///Users/runner/work/vscode-didact/vscode-didact/.vscode-test/vscode-darwin-1.55.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:1589:11587)
    at s._receiveRequest (file:///Users/runner/work/vscode-didact/vscode-didact/.vscode-test/vscode-darwin-1.55.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:1589:10257)
    at s._receiveOneMessage (file:///Users/runner/work/vscode-didact/vscode-didact/.vscode-test/vscode-darwin-1.55.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:1589:9043)
    at file:///Users/runner/work/vscode-didact/vscode-didact/.vscode-test/vscode-darwin-1.55.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:1589:7144
    at c.fire (file:///Users/runner/work/vscode-didact/vscode-didact/.vscode-test/vscode-darwin-1.55.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:60:1836)
    at o.fire (file:///Users/runner/work/vscode-didact/vscode-didact/.vscode-test/vscode-darwin-1.55.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:76:16186)
    at i._receiveMessage (file:///Users/runner/work/vscode-didact/vscode-didact/.vscode-test/vscode-darwin-1.55.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:76:21444)
    at file:///Users/runner/work/vscode-didact/vscode-didact/.vscode-test/vscode-darwin-1.55.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:76:18330
    at c.fire (file:///Users/runner/work/vscode-didact/vscode-didact/.vscode-test/vscode-darwin-1.55.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:60:1836)
    at u.acceptChunk (file:///Users/runner/work/vscode-didact/vscode-didact/.vscode-test/vscode-darwin-1.55.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:76:13551)
    at file:///Users/runner/work/vscode-didact/vscode-didact/.vscode-test/vscode-darwin-1.55.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:76:12899
    at Socket.k (file:///Users/runner/work/vscode-didact/vscode-didact/.vscode-test/vscode-darwin-1.55.2/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:2781:52777)
    at Socket.emit (events.js:315:20)
    at addChunk (_stream_readable.js:295:12)
    at readableAddChunk (_stream_readable.js:271:9)
    at Socket.Readable.push (_stream_readable.js:212:10)
    at Pipe.onStreamRead (internal/stream_base_commons.js:186:23)
```

I have traced it down to the lines I commented on below. Open to any suggestions!

Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>