### PR TITLE
removing unused DIDACT_DEFAULT_URL import

### DIFF
--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -28,7 +28,7 @@ import { handleExtFilePath, handleProjectFilePath } from './commandHandler';
 import * as download from 'download';
 import { didactManager } from './didactManager';
 import { parse } from 'node-html-parser';
-import { addNewTutorialWithNameAndCategoryForDidactUri, delay, DIDACT_DEFAULT_URL, getCachedOutputChannel, getCurrentFileSelectionPath, getDefaultUrl, getInsertLFForCLILinkSetting, getLinkTextForCLILinkSetting, getValue, getWorkspacePath, registerTutorialWithCategory, rememberOutputChannel } from './utils';
+import { addNewTutorialWithNameAndCategoryForDidactUri, delay, getCachedOutputChannel, getCurrentFileSelectionPath, getDefaultUrl, getInsertLFForCLILinkSetting, getLinkTextForCLILinkSetting, getValue, getWorkspacePath, registerTutorialWithCategory, rememberOutputChannel } from './utils';
 
 const tmp = require('tmp');
 const fetch = require('node-fetch');


### PR DESCRIPTION
Small sonar issue missed in the first pass
https://sonarcloud.io/project/issues?id=vscode-didact&open=AXmjwvWa8trMiAr3VkkB&resolved=false&severities=MINOR

Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>