### PR TITLE
FUSETOOLS2-1152 - update test due to Powershell integration in VS Code

### DIFF
--- a/src/test/suite/stubDemoTutorial.test.ts
+++ b/src/test/suite/stubDemoTutorial.test.ts
@@ -34,8 +34,8 @@ suite('stub out a tutorial', () => {
 
 	test('that we can send an echo command to the terminal and get the response', async () => {
 		const name = 'echoTerminal';
-		const text = `echo Hello World ${name}`;
-		const result = `Hello World echoTerminal`;
+		const text = `echo "Hello World ${name}"`;
+		const result = `Hello World ${name}`;
 		await validateTerminalResponse(name, text, result);
 	});
 


### PR DESCRIPTION
since last release of VS Code, there is now PowerShell used. The echo command in
powershell is handling spaces when not enclosed by quotes as line
separator.

Providing text with double-quotes to have similar output behavior on all
platforms and keep demoing how to have echo text with space

Signed-off-by: Aurélien Pupier <apupier@redhat.com>