### PR TITLE
FUSETOOLS2-1290 - migrate Docker image on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 job_default: &job_defaults
   working_directory: ~/vscode-didact
   docker:
-    - image: circleci/node:lts-browsers
+    - image: cimg/node:lts-browsers
   
 jobs:
   build:


### PR DESCRIPTION
circleci/* are deprecated and to be replaced with cimg/*
