### PR TITLE
1359 fix main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,10 @@ jobs:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: install-typescript
-          command: sudo npm install -g typescript
+          command: npm install --prefix=$HOME/.local -g typescript
       - run:
           name: install-vsce
-          command: sudo npm install -g vsce
+          command: npm install --prefix=$HOME/.local -g vsce
       - run:
           name: npm-ci
           command: npm ci
@@ -42,7 +42,7 @@ jobs:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: install-typescript
-          command: sudo npm install -g typescript
+          command: npm install --prefix=$HOME/.local -g typescript
       - run:
           name: npm-ci
           command: npm ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 job_default: &job_defaults
   working_directory: ~/vscode-didact
   docker:
-    - image: cimg/node:lts-browsers
+    - image: cimg/node:14.18-browsers
   
 jobs:
   build:


### PR DESCRIPTION
- FUSETOOLS2-1359 - vsce 2.2.0 requires node 14. Underlying image is now using nvm, so switch to use nvm to setup the
wanted version
- FUSETOOLS2-1359 - avoid use of sudo to install global npm dependencies on Circle CI. It was previously required, now it is causing build failures. See https://stackoverflow.com/questions/50915469/simple-circleci-2-0-configuration-fails-for-global-npm-package-installation
for workaround