### PR TITLE
FUSETOOLS2-1160 - partial fix for embedded tutorial between upgrade of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the "vscode-didact" extension will be documented in this 
 
 ## 0.4.1
 
+- Fix embedded tutorials after an upgrade. It requires having the setting `Auto-add default tutorials` kept to default value `true`
 - Integrated with the built-in VS Code Markdown Preview (Ctrl+Shift+V). Note that Didact links do not work from the built-in preview
   - Also note that the built-in preview for the AsciiDoc extension (https://marketplace.visualstudio.com/items?itemName=asciidoctor.asciidoctor-vscode) now works, though the stylesheets are not the same and Didact links do not work from the AsciiDoc preview
 - Changed `Didact: Start Didact Tutorial from File` hotkeys from `Ctrl/Cmd+Shift+V` to `Ctrl/Cmd+Alt+D` to avoid conflicting with the Markdown and AsciiDoc preview functionality. This keybinding can be changed from the VS Code `Keyboard Shortcuts` window (`File->Preferences->Keyboard Shortcuts`)


### PR DESCRIPTION
extensions

this is straightforward, not very flexible and covers only the case of
users that has not changed the auto-reload on startup embedded
tutorials. Having a proper registry handling all the kinds of tutorials
would be better but given allocated time on VS Code Didact and impact of
other fixes not yet released and as this fix is working in default case
I think we should go with this "mitigation fix" and consider to be in a
releasable state.

how to test:

- install Didact 0.4.0
- build a didact 0.4.1 vsix locally from this PR branch
- install the 0.4.1 vsix
- restart (and not only reload otherwise the extension cache folder is not cleared by VS Code)
- open a didact tutorial.