### PR TITLE
FUSETOOLS2-841 - provide fix for several warnings pointed by linter

### DIFF
--- a/src/Telemetry.ts
+++ b/src/Telemetry.ts
@@ -30,7 +30,7 @@ export class DidactTelemetry {
 		return this.telemetryService;
 	}
 
-	public async sendCommandTracking(commandId: string) {
+	public async sendCommandTracking(commandId: string): Promise<void> {
 		const telemetryEvent: TelemetryEvent = {
 			type: 'track',
 			name: 'didact.didactCommand',
@@ -41,7 +41,7 @@ export class DidactTelemetry {
 		(await this.telemetryService).send(telemetryEvent);
 	}
 
-	public async sendDidactOpenTypeTracking(filePath: string) {
+	public async sendDidactOpenTypeTracking(filePath: string): Promise<void> {
 		const fileExt = getFileExtension(filePath);
 		const telemetryEvent: TelemetryEvent = {
 			type: 'track',

--- a/src/extensionFunctions.ts
+++ b/src/extensionFunctions.ts
@@ -832,7 +832,7 @@ export async function downloadAndUnzipFile(httpFileUrl : string, installFolder :
 	}
 }
 
-export async function copyFileFromURLtoLocalURI(httpurl : any, fileName? : string, fileuri? : string, unzip = false): Promise<void>{
+export async function copyFileFromURLtoLocalURI(httpurl : string, fileName? : string, fileuri? : string, unzip = false): Promise<void>{
 	let projectFilePath = '';
 
 	if (fileuri && fileuri.length > 0) {

--- a/src/test/suite/_extension.test.ts
+++ b/src/test/suite/_extension.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { getAutoInstallDefaultTutorialsSetting, getOpenAtStartupSetting, getRegisteredTutorials, registerTutorialWithCategory } from '../../utils';
-import { DEFAULT_TUTORIAL_CATEGORY, DEFAULT_TUTORIAL_NAME } from '../../extension';
+import { getAutoInstallDefaultTutorialsSetting, getOpenAtStartupSetting, getRegisteredTutorials } from '../../utils';
+import { DEFAULT_TUTORIAL_CATEGORY } from '../../extension';
 import { expect } from 'chai';
 import { ensureExtensionActivated } from './Utils';
-import { getContext } from '../../extensionFunctions';
 
 suite('Extension Test Suite', () => {
 	const extensionId = 'redhat.vscode-didact';

--- a/src/test/suite/completions.test.ts
+++ b/src/test/suite/completions.test.ts
@@ -105,7 +105,7 @@ async function acceptFirstSuggestion(uri: vscode.Uri, _disposables: vscode.Dispo
 }
 
 // https://github.com/microsoft/vscode/blob/94c9ea46838a9a619aeafb7e8afd1170c967bb55/extensions/typescript-language-features/src/test/testUtils.ts#L141
-export function onChangedDocument(documentUri: vscode.Uri, disposables: vscode.Disposable[]) {
+export function onChangedDocument(documentUri: vscode.Uri, disposables: vscode.Disposable[]): Promise<vscode.TextDocument> {
 	return new Promise<vscode.TextDocument>(resolve => vscode.workspace.onDidChangeTextDocument(e => {
 		if (e.document.uri.toString() === documentUri.toString()) {
 			resolve(e.document);
@@ -118,7 +118,7 @@ export async function retryUntilDocumentChanges(
 	documentUri: vscode.Uri,
 	options: { retries: number, timeout: number },
 	disposables: vscode.Disposable[],
-	exec: () => Thenable<unknown>, ) {
+	exec: () => Thenable<unknown>, ): Promise<void | vscode.TextDocument> {
 	const didChangeDocument = onChangedDocument(documentUri, disposables);
 	let done = false;
 	const result = await Promise.race([

--- a/src/test/suite/registry.test.ts
+++ b/src/test/suite/registry.test.ts
@@ -3,8 +3,7 @@ import {getRegisteredTutorials, getDidactCategories, getTutorialsForCategory, ge
 import {before} from 'mocha';
 import * as vscode from 'vscode';
 import { ADD_TUTORIAL_TO_REGISTRY, getContext, REGISTER_TUTORIAL } from '../../extensionFunctions';
-import { DEFAULT_TUTORIAL_CATEGORY, DEFAULT_TUTORIAL_NAME, didactTreeView, didactTutorialsProvider } from '../../extension';
-import { waitUntil } from 'async-wait-until';
+import { DEFAULT_TUTORIAL_CATEGORY, DEFAULT_TUTORIAL_NAME, didactTreeView } from '../../extension';
 
 const name = 'new-tutorial';
 const category = 'some-category';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,7 +135,7 @@ export function getRegisteredTutorials() : string[] | undefined {
 	return extensionFunctions.getContext().workspaceState.get(DIDACT_REGISTERED_SETTING);
 }
 
-export async function registerTutorialWithJSON( jsonObject: any) {
+export async function registerTutorialWithJSON( jsonObject: any): Promise<void> {
 	const newTutorial : Tutorial = jsonObject as ITutorial;
 	return registerTutorialWithClass(newTutorial);
 }
@@ -404,7 +404,7 @@ async function quickPickCategory(
 	acceptInput = true): Promise<string[]> {
 	const options = categories.map(tag => ({ label: tag }));
 
-	return new Promise((resolve, _) => {
+	return new Promise((resolve) => {
 		const quickPick = window.createQuickPick();
 		let placeholder = "Select a Tutorial Category.";
 


### PR DESCRIPTION
before:
```
(base) [apupier@localhost vscode-didact]$ npm run compile

> vscode-didact@0.4.1 compile /home/apupier/git/vscode-didact
> tsc -p ./ && npm run lint


> vscode-didact@0.4.1 lint /home/apupier/git/vscode-didact
> eslint src --ext .ts


/home/apupier/git/vscode-didact/src/Telemetry.ts
  33:2  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
  44:2  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types

/home/apupier/git/vscode-didact/src/asciidocUtils.ts
  20:32  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  24:67  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/commandHandler.ts
   28:17  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  152:34  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  230:38  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  235:54  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/didactManager.ts
  134:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  137:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/didactUriCompletionItemProvider.ts
   33:29  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   50:3   warning  'token' is defined but never used         @typescript-eslint/no-unused-vars
   50:36  warning  'context' is defined but never used       @typescript-eslint/no-unused-vars
  184:47  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/extension.ts
   42:75  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  133:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/extensionFunctions.ts
   114:18   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
   149:46   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
   374:20   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
   486:38   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
   596:80   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
   597:18   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
   611:48   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
   630:43   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
   688:57   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
   735:18   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
   759:167  warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
   835:49   warning  Argument 'httpurl' should be typed with a non-any type  @typescript-eslint/explicit-module-boundary-types
   835:59   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
   869:56   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
   880:19   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
  1018:51   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
  1022:53   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
  1028:19   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
  1045:19   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
  1082:82   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any
  1230:22   warning  Unexpected any. Specify a different type                @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/scaffoldUtils.ts
   23:17  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
   56:23  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
   72:45  warning  Argument 'json' should be typed with a non-any type  @typescript-eslint/explicit-module-boundary-types
   72:51  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
   72:87  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  135:40  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  135:52  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  135:88  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  138:31  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  169:45  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  169:59  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  169:95  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  171:34  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/test/suite/Utils.ts
  63:20  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  70:52  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/test/suite/_extension.test.ts
   3:98  warning  'registerTutorialWithCategory' is defined but never used  @typescript-eslint/no-unused-vars
   4:37  warning  'DEFAULT_TUTORIAL_NAME' is defined but never used         @typescript-eslint/no-unused-vars
   7:10  warning  'getContext' is defined but never used                    @typescript-eslint/no-unused-vars
  38:21  warning  Unexpected any. Specify a different type                  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/test/suite/commandHandler.test.ts
  41:17  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/test/suite/completions.test.ts
  108:8  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
  117:8  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types

/home/apupier/git/vscode-didact/src/test/suite/demoTutorials.test.ts
  66:20  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/test/suite/didact.test.ts
  145:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  166:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  194:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  215:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  232:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  254:21  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  264:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/test/suite/didactUriCompletionItemProvider.test.ts
   52:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  254:10  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  255:10  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/test/suite/registry.test.ts
    6:76  warning  'didactTutorialsProvider' is defined but never used  @typescript-eslint/no-unused-vars
    7:10  warning  'waitUntil' is defined but never used                @typescript-eslint/no-unused-vars
  174:20  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/test/suite/stubDemoTutorial.test.ts
  47:26  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/utils.ts
  138:8   warning  Missing return type on function                            @typescript-eslint/explicit-module-boundary-types
  138:49  warning  Argument 'jsonObject' should be typed with a non-any type  @typescript-eslint/explicit-module-boundary-types
  138:61  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any
  152:20  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any
  204:20  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any
  220:20  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any
  235:20  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any
  252:20  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any
  330:49  warning  Argument 'inJson' should be typed with a non-any type      @typescript-eslint/explicit-module-boundary-types
  330:58  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any
  407:31  warning  '_' is defined but never used                              @typescript-eslint/no-unused-vars
  419:22  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any
  463:20  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any

✖ 87 problems (0 errors, 87 warnings)
```

after:
```
(base) [apupier@localhost vscode-didact]$ npm run compile

> vscode-didact@0.4.1 compile /home/apupier/git/vscode-didact
> tsc -p ./ && npm run lint


> vscode-didact@0.4.1 lint /home/apupier/git/vscode-didact
> eslint src --ext .ts


/home/apupier/git/vscode-didact/src/asciidocUtils.ts
  20:32  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  24:67  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/commandHandler.ts
   28:17  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  152:34  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  230:38  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  235:54  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/didactManager.ts
  134:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  137:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/didactUriCompletionItemProvider.ts
   33:29  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   50:3   warning  'token' is defined but never used         @typescript-eslint/no-unused-vars
   50:36  warning  'context' is defined but never used       @typescript-eslint/no-unused-vars
  184:47  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/extension.ts
   42:75  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  133:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/extensionFunctions.ts
   114:18   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   149:46   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   374:20   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   486:38   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   596:80   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   597:18   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   611:48   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   630:43   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   688:57   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   735:18   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   759:167  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   869:56   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   880:19   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1018:51   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1022:53   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1028:19   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1045:19   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1082:82   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  1230:22   warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/scaffoldUtils.ts
   23:17  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
   56:23  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
   72:45  warning  Argument 'json' should be typed with a non-any type  @typescript-eslint/explicit-module-boundary-types
   72:51  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
   72:87  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  135:40  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  135:52  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  135:88  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  138:31  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  169:45  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  169:59  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  169:95  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
  171:34  warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/test/suite/Utils.ts
  63:20  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  70:52  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/test/suite/_extension.test.ts
  37:21  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/test/suite/commandHandler.test.ts
  41:17  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/test/suite/demoTutorials.test.ts
  66:20  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/test/suite/didact.test.ts
  145:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  166:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  194:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  215:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  232:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  254:21  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  264:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/test/suite/didactUriCompletionItemProvider.test.ts
   52:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  254:10  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  255:10  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/test/suite/registry.test.ts
  173:20  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/test/suite/stubDemoTutorial.test.ts
  47:26  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/apupier/git/vscode-didact/src/utils.ts
  138:49  warning  Argument 'jsonObject' should be typed with a non-any type  @typescript-eslint/explicit-module-boundary-types
  138:61  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any
  152:20  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any
  204:20  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any
  220:20  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any
  235:20  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any
  252:20  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any
  330:49  warning  Argument 'inJson' should be typed with a non-any type      @typescript-eslint/explicit-module-boundary-types
  330:58  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any
  419:22  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any
  463:20  warning  Unexpected any. Specify a different type                   @typescript-eslint/no-explicit-any

✖ 74 problems (0 errors, 74 warnings)
```
