### PR TITLE
FUSETOOLS2-1514 - use await on a delay

### DIFF
--- a/src/test/suite/stubDemoTutorial.test.ts
+++ b/src/test/suite/stubDemoTutorial.test.ts
@@ -111,7 +111,7 @@ suite('stub out a tutorial', () => {
 
 	async function executeAndWait(command: string): Promise<void> {
 		await commands.executeCommand(command);
-		delay(200);
+		await delay(200);
 	}
 
 	function getNamedTerminal(terminalName : string): Terminal | undefined {


### PR DESCRIPTION
otherwise the delay is useless.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>